### PR TITLE
Dice bags spawn the special die in the bag

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -358,16 +358,3 @@
 				/obj/item/circuitboard/computer/apc_control,
 				/obj/item/circuitboard/computer/robotics
 				)
-/obj/effect/spawner/lootdrop/special_die
-	name = "special die spawner"
-	loot = list(
-				/obj/item/dice/d1 = 1,
-				/obj/item/dice/d2 = 1,
-				/obj/item/dice/fudge = 1,
-				/obj/item/dice/d6/space = 1,
-				/obj/item/dice/d00 = 1,
-				/obj/item/dice/eightbd20 = 1,
-				/obj/item/dice/fourdd6 = 1,
-				/obj/item/dice/d100 = 1
-				)
-

--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -5,15 +5,26 @@
 	desc = "Contains all the luck you'll ever need."
 	icon = 'icons/obj/dice.dmi'
 	icon_state = "dicebag"
+	var/list/special_die = list(
+				/obj/item/dice/d1,
+				/obj/item/dice/d2,
+				/obj/item/dice/fudge,
+				/obj/item/dice/d6/space,
+				/obj/item/dice/d00,
+				/obj/item/dice/eightbd20,
+				/obj/item/dice/fourdd6,
+				/obj/item/dice/d100
+				)
 
 /obj/item/storage/pill_bottle/dice/PopulateContents()
-	new /obj/effect/spawner/lootdrop/special_die(src)
 	new /obj/item/dice/d4(src)
 	new /obj/item/dice/d6(src)
 	new /obj/item/dice/d8(src)
 	new /obj/item/dice/d10(src)
 	new /obj/item/dice/d12(src)
 	new /obj/item/dice/d20(src)
+	var/picked = pick(special_die)
+	new picked(src)
 
 /obj/item/storage/pill_bottle/dice/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is gambling with death! It looks like [user.p_theyre()] trying to commit suicide!</span>")


### PR DESCRIPTION
mirror of #47561
script crashed

## Changelog
:cl: Skgolol
fix: Bag of dice now has a special die INSIDE the bag.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
