### PR TITLE
port some of citadel's lighting changes

### DIFF
--- a/austation/changes.txt
+++ b/austation/changes.txt
@@ -15,3 +15,4 @@ Terra:OOC remains active during sandbox rounds
 Terra:Closets no longer have drag slowdown
 Effectism:Gangs and Gangmageddon gamemodes
 Effectism:Fusion max temperature config
+Effectism:Optimized lighting algorithms from citadel

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -1,11 +1,13 @@
 // This is where the fun begins.
 // These are the main datums that emit light.
 
+// Austation begin
 // Thanks to Lohikar for flinging this tiny bit of code at me, increasing my brain cell count from 1 to 2 in the process.
 // This macro will only offset up to 1 tile, but anything with a greater offset is an outlier and probably should handle its own lighting offsets.
 // Anything pixelshifted 16px or more will be considered on the next tile.
 #define GET_APPROXIMATE_PIXEL_DIR(PX, PY) ((!(PX) ? 0 : ((PX >= 16 ? EAST : (PX <= -16 ? WEST : 0)))) | (!PY ? 0 : (PY >= 16 ? NORTH : (PY <= -16 ? SOUTH : 0))))
 #define UPDATE_APPROXIMATE_PIXEL_TURF var/_mask = GET_APPROXIMATE_PIXEL_DIR(top_atom.pixel_x, top_atom.pixel_y); pixel_turf = _mask ? (get_step(source_turf, _mask) || source_turf) : source_turf
+// Austation end
 
 /datum/light_source
 	var/atom/top_atom        // The atom we're emitting light from (for example a mob if we're from a flashlight that's being held).
@@ -117,6 +119,7 @@
 // As such this all gets counted as a single line.
 // The braces and semicolons are there to be able to do this on a single line.
 
+// Austation begin
 // Original lighting falloff calculation. This looks the best out of the three. However, this is also the most expensive.
 //#define LUM_FALLOFF(C, T) (1 - CLAMP01(sqrt((C.x - T.x) ** 2 + (C.y - T.y) ** 2 + LIGHTING_HEIGHT) / max(1, light_range)))
 
@@ -136,6 +139,7 @@
 // Linear lighting falloff but with an octagonal shape in place of a diamond shape (from CIT)
 #define LUM_FALLOFF(C, T) (1 - CLAMP01(max(GET_LUM_DIST(abs(C.x - T.x), abs(C.y - T.y)),LIGHTING_HEIGHT) / max(1, light_range+1)))
 #define GET_LUM_DIST(DISTX, DISTY) (DISTX + DISTY + abs(DISTX - DISTY)*0.4)
+// Austation end
 
 #define APPLY_CORNER(C)                      \
 	. = LUM_FALLOFF(C, pixel_turf);          \
@@ -321,5 +325,7 @@
 #undef LUM_FALLOFF
 #undef REMOVE_CORNER
 #undef APPLY_CORNER
+// Austation begin -- macros are only used here
 #undef GET_APPROXIMATE_PIXEL_DIR
 #undef UPDATE_APPROXIMATE_PIXEL_TURF
+// Austation end

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -1,6 +1,12 @@
 // This is where the fun begins.
 // These are the main datums that emit light.
 
+// Thanks to Lohikar for flinging this tiny bit of code at me, increasing my brain cell count from 1 to 2 in the process.
+// This macro will only offset up to 1 tile, but anything with a greater offset is an outlier and probably should handle its own lighting offsets.
+// Anything pixelshifted 16px or more will be considered on the next tile.
+#define GET_APPROXIMATE_PIXEL_DIR(PX, PY) ((!(PX) ? 0 : ((PX >= 16 ? EAST : (PX <= -16 ? WEST : 0)))) | (!PY ? 0 : (PY >= 16 ? NORTH : (PY <= -16 ? SOUTH : 0))))
+#define UPDATE_APPROXIMATE_PIXEL_TURF var/_mask = GET_APPROXIMATE_PIXEL_DIR(top_atom.pixel_x, top_atom.pixel_y); pixel_turf = _mask ? (get_step(source_turf, _mask) || source_turf) : source_turf
+
 /datum/light_source
 	var/atom/top_atom        // The atom we're emitting light from (for example a mob if we're from a flashlight that's being held).
 	var/atom/source_atom     // The atom that we belong to.
@@ -37,7 +43,7 @@
 		LAZYADD(top_atom.light_sources, src)
 
 	source_turf = top_atom
-	pixel_turf = get_turf_pixel(top_atom) || source_turf
+	UPDATE_APPROXIMATE_PIXEL_TURF // Austation -- lighting offsets
 
 	light_power = source_atom.light_power
 	light_range = source_atom.light_range
@@ -110,7 +116,26 @@
 // If you're wondering what's with the backslashes, the backslashes cause BYOND to not automatically end the line.
 // As such this all gets counted as a single line.
 // The braces and semicolons are there to be able to do this on a single line.
-#define LUM_FALLOFF(C, T) (1 - CLAMP01(sqrt((C.x - T.x) ** 2 + (C.y - T.y) ** 2 + LIGHTING_HEIGHT) / max(1, light_range)))
+
+// Original lighting falloff calculation. This looks the best out of the three. However, this is also the most expensive.
+//#define LUM_FALLOFF(C, T) (1 - CLAMP01(sqrt((C.x - T.x) ** 2 + (C.y - T.y) ** 2 + LIGHTING_HEIGHT) / max(1, light_range)))
+
+// Cubic lighting falloff. This has the *exact* same range as the original lighting falloff
+// calculation, down to the exact decimal, but it looks a little unnatural due to the harsher
+// falloff and how it's generally brighter across the board.
+//#define LUM_FALLOFF(C, T) (1 - CLAMP01((((C.x - T.x) * (C.x - T.x)) + ((C.y - T.y) * (C.y - T.y)) + LIGHTING_HEIGHT) / max(1, light_range*light_range)))
+
+// Linear lighting falloff. This resembles the original lighting falloff calculation the best,
+// but results in lights having a slightly larger range, which is most noticable with large light sources.
+// This also results in lights being diamond-shaped, fuck. This looks the darkest out of the
+// three due to how lights are brighter closer to the source compared to the original falloff
+// algorithm. This falloff method also does not at all take into account lighting height, as
+// it acts as a flat reduction to light range with this method.
+//#define LUM_FALLOFF(C, T) (1 - CLAMP01(((abs(C.x - T.x) + abs(C.y - T.y))) / max(1, light_range+1)))
+
+// Linear lighting falloff but with an octagonal shape in place of a diamond shape (from CIT)
+#define LUM_FALLOFF(C, T) (1 - CLAMP01(max(GET_LUM_DIST(abs(C.x - T.x), abs(C.y - T.y)),LIGHTING_HEIGHT) / max(1, light_range+1)))
+#define GET_LUM_DIST(DISTX, DISTY) (DISTX + DISTY + abs(DISTX - DISTY)*0.4)
 
 #define APPLY_CORNER(C)                      \
 	. = LUM_FALLOFF(C, pixel_turf);          \
@@ -190,11 +215,11 @@
 	if (isturf(top_atom))
 		if (source_turf != top_atom)
 			source_turf = top_atom
-			pixel_turf = source_turf
+			UPDATE_APPROXIMATE_PIXEL_TURF // Austation -- lighting offsets
 			update = TRUE
 	else if (top_atom.loc != source_turf)
 		source_turf = top_atom.loc
-		pixel_turf = get_turf_pixel(top_atom)
+		UPDATE_APPROXIMATE_PIXEL_TURF // Austation -- lighting offsets
 		update = TRUE
 	else
 		var/P = get_turf_pixel(top_atom)
@@ -296,3 +321,5 @@
 #undef LUM_FALLOFF
 #undef REMOVE_CORNER
 #undef APPLY_CORNER
+#undef GET_APPROXIMATE_PIXEL_DIR
+#undef UPDATE_APPROXIMATE_PIXEL_TURF

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -1,8 +1,7 @@
 // This is where the fun begins.
 // These are the main datums that emit light.
 
-// Austation begin
-// Thanks to Lohikar for flinging this tiny bit of code at me, increasing my brain cell count from 1 to 2 in the process.
+// Austation begin -- Thanks to Lohikar for flinging this tiny bit of code at me, increasing my brain cell count from 1 to 2 in the process.
 // This macro will only offset up to 1 tile, but anything with a greater offset is an outlier and probably should handle its own lighting offsets.
 // Anything pixelshifted 16px or more will be considered on the next tile.
 #define GET_APPROXIMATE_PIXEL_DIR(PX, PY) ((!(PX) ? 0 : ((PX >= 16 ? EAST : (PX <= -16 ? WEST : 0)))) | (!PY ? 0 : (PY >= 16 ? NORTH : (PY <= -16 ? SOUTH : 0))))
@@ -119,7 +118,7 @@
 // As such this all gets counted as a single line.
 // The braces and semicolons are there to be able to do this on a single line.
 
-// Austation begin
+// Austation begin -- There are a couple of different lighting falloff macros here.
 // Original lighting falloff calculation. This looks the best out of the three. However, this is also the most expensive.
 //#define LUM_FALLOFF(C, T) (1 - CLAMP01(sqrt((C.x - T.x) ** 2 + (C.y - T.y) ** 2 + LIGHTING_HEIGHT) / max(1, light_range)))
 


### PR DESCRIPTION

![](https://cdn.discordapp.com/attachments/629975198313086976/642668498811617280/rtx_on_rtx_off.png)
Looks quite a bit prettier, and apparently improves performance somewhat.
Lighting is a lot darker now, especially at night, but it doesn't seem to be a huge issue on other servers that use this.

## Changelog
:cl: deathride58
tweak: Lighting now uses a linear algorithm to calculate falloff instead of an inverse-square algorithm.
/:cl: