### PR TITLE
Working minimum player config

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -64,6 +64,9 @@
 		if(player.ready == PLAYER_READY_TO_PLAY)
 			playerC++
 	if(!GLOB.Debug2)
+		var/list/min_pop = config.Get(/datum/config_entry/keyed_list/min_pop) //Austation begin -- Allows for overriding of population requirements for gamemodes, will cause errors if set too low
+		if((config_tag in min_pop))
+			required_players = min_pop[config_tag] //Austation end
 		if(playerC < required_players || (maximum_players >= 0 && playerC > maximum_players))
 			return 0
 	antag_candidates = get_players_for_role(antag_flag)


### PR DESCRIPTION
Allows for adjustment of player requirements to suit our population better. Will still default to original requirements if no requirements are manually set. 
This was probably the intended functionality.

## Changelog
:cl:
config: player requirements for gamemodes can be overridden via config.
/:cl:
