### PR TITLE
Enabling random lawsets for AI at round start

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -354,7 +354,7 @@ NEAR_DEATH_EXPERIENCE
 ## Set to 1 for "custom", silicons will start with the custom laws defined in silicon_laws.txt. (If silicon_laws.txt is empty, the AI will spawn with asimov and Custom boards will auto-delete.)
 ## Set to 2 for "random", silicons will start with a random lawset picked from random laws specified below.
 ## Set to 3 for "weighted random", using values in "silicon_weights.txt", a law will be selected, with weights specifed in that file.
-DEFAULT_LAWS 0
+DEFAULT_LAWS 2
 
 ## RANDOM LAWS ##
 ## ------------------------------------------------------------------------------------------
@@ -363,18 +363,19 @@ DEFAULT_LAWS 0
 
 ## standard-ish laws. These are fairly ok to run
 RANDOM_LAWS asimov
-RANDOM_LAWS asimovpp
-RANDOM_LAWS paladin
-RANDOM_LAWS robocop
+#RANDOM_LAWS asimovpp
+#RANDOM_LAWS paladin
+RANDOM_LAWS paladin5
+#RANDOM_LAWS robocop
 RANDOM_LAWS corporate
 
 ## Quirky laws. Shouldn't cause too much harm
 #RANDOM_LAWS hippocratic
 #RANDOM_LAWS maintain
-#RANDOM_LAWS drone
+RANDOM_LAWS drone
 #RANDOM_LAWS liveandletlive
 #RANDOM_LAWS peacekeeper
-#RANDOM_LAWS reporter
+RANDOM_LAWS reporter
 #RANDOM_LAWS hulkamania
 
 ## Bad idea laws. Probably shouldn't enable these


### PR DESCRIPTION
Had a bit of a discussion and wanted to make the AI lawsets at round start randomised. The files themselves may not change but this is mostly to spark some discussion as the configs themselves will be changed on the servers end rather than on the github mostly. So please gives some more suggestions what lawsets should be nabled like asimovpp, crewsimov, and all that.

The lawsets that I have active are:
Asimov
Paladin5
Corporate
Drone
Reporter

