### PR TITLE
Fixes an issue where module upgrades would be consumed with no change when borg had no mind

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -639,7 +639,7 @@
 /obj/item/borg/upgrade/transform/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if(.)
-		R.module.transform_to(new_module)
+		 . = R.module.transform_to(new_module) // austation -- this needs to return false if transformation fails
 
 /obj/item/borg/upgrade/transform/clown
 	name = "borg module picker (Clown)"
@@ -697,4 +697,4 @@
 	if (.)
 		var/obj/item/borg/apparatus/beaker/extra/E = locate() in R.module.modules
 		if (E)
-			R.module.remove_module(E, TRUE) 
+			R.module.remove_module(E, TRUE)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -639,7 +639,7 @@
 /obj/item/borg/upgrade/transform/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if(.)
-		 . = R.module.transform_to(new_module) // austation -- this needs to return false if transformation fails
+		. = R.module.transform_to(new_module) // austation -- this needs to return false if transformation fails
 
 /obj/item/borg/upgrade/transform/clown
 	name = "borg module picker (Clown)"


### PR DESCRIPTION
## About The Pull Request
Title.
There was an issue (first noticed with AI shell) where if you used a module board on a borg that had multiple options for icons, it would fail to transform but consume the board because the client wasn't available to receive the popup. Now the board just drops on the floor when it fails because it checks the return from the module change proc

## Why It's Good For The Game
bug fix

## Changelog
:cl:
fix: fixed issue with module boards and multiple icons
/:cl: