### PR TITLE
Defines hat_offset for new sprites

### DIFF
--- a/austation/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/austation/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -14,15 +14,19 @@
 		if("Sleek")
 			R.icon = 'austation/icons/mob/robot.dmi'
 			cyborg_base_icon = "sleekmed"
+			hat_offset = -1
 		if("Marina")
 			R.icon = 'austation/icons/mob/robot.dmi'
 			cyborg_base_icon = "marinamed"
+			hat_offset = 2
 		if("Eyebot")
 			R.icon = 'austation/icons/mob/robot.dmi'
 			cyborg_base_icon = "eyebotmed"
+			hat_offset = -3
 		if("Heavy")
 			R.icon = 'austation/icons/mob/robot.dmi'
 			cyborg_base_icon = "heavymed"
+			hat_offset = -4
 	return ..()
 
 /obj/item/robot_module/engineering/be_transformed_to(obj/item/robot_module/old_module) //Pick a icon starts here
@@ -37,18 +41,23 @@
 		if("Heavy")
 			R.icon = 'austation/icons/mob/robot.dmi'
 			cyborg_base_icon = "heavyeng"
+			hat_offset = -4
 		if("Sleek")
 			R.icon = 'austation/icons/mob/robot.dmi'
 			cyborg_base_icon = "sleekeng"
+			hat_offset = -1
 		if("Marina")
 			R.icon = 'austation/icons/mob/robot.dmi'
 			cyborg_base_icon = "marinaeng"
+			hat_offset = 2
 		if("Can")
 			R.icon = 'austation/icons/mob/robot.dmi'
 			cyborg_base_icon = "caneng"
+			hat_offset = 3
 		if("Spider")
 			R.icon = 'austation/icons/mob/robot.dmi'
 			cyborg_base_icon = "spidereng"
+			hat_offset = -3
 		if("Handy")
 			R.icon = 'austation/icons/mob/robot.dmi'
 			cyborg_base_icon = "handyeng"
@@ -66,18 +75,23 @@
 		if("Heavy")
 			R.icon = 'austation/icons/mob/robot.dmi'
 			cyborg_base_icon = "heavysec"
+			hat_offset = -4
 		if("Sleek")
 			R.icon = 'austation/icons/mob/robot.dmi'
 			cyborg_base_icon = "sleeksec"
+			hat_offset = -1
 		if("Can")
 			R.icon = 'austation/icons/mob/robot.dmi'
 			cyborg_base_icon = "cansec"
+			hat_offset = 3
 		if("Marina")
 			R.icon = 'austation/icons/mob/robot.dmi'
 			cyborg_base_icon = "marinasec"
+			hat_offset = 2
 		if("Spider")
 			R.icon = 'austation/icons/mob/robot.dmi'
 			cyborg_base_icon = "spidersec"
+			hat_offset = -3
 	return ..()
 
 /obj/item/robot_module/peacekeeper/be_transformed_to(obj/item/robot_module/old_module) //Pick a icon starts here
@@ -106,11 +120,14 @@
 		if("Can")
 			R.icon = 'austation/icons/mob/robot.dmi'
 			cyborg_base_icon = "canjan"
+			hat_offset = 3
 		if("Marina")
 			R.icon = 'austation/icons/mob/robot.dmi'
 			cyborg_base_icon = "marinajan"
+			hat_offset = 2
 		if("Sleek")
 			R.icon = 'austation/icons/mob/robot.dmi'
 			cyborg_base_icon = "sleekjan"
+			hat_offset = -1
 	return ..()
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -608,22 +608,28 @@
 			special_light_key = "miner"
 		if("Spider Miner")
 			cyborg_base_icon = "spidermin"
+			hat_offset = -3 // austation -- setting offset
 		// austation begin -- adding choices
 		if("Marina")
 			R.icon = 'austation/icons/mob/robot.dmi'
 			cyborg_base_icon = "marinamin"
+			hat_offset = 2
 		if("Heavy")
 			R.icon = 'austation/icons/mob/robot.dmi'
 			cyborg_base_icon = "heavymin"
+			hat_offset = -3
 		if("Can")
 			R.icon = 'austation/icons/mob/robot.dmi'
 			cyborg_base_icon = "canmin"
+			hat_offset = 3
 		if("Droid")
 			R.icon = 'austation/icons/mob/robot.dmi'
 			cyborg_base_icon = "cminer"
+			hat_offset = 4
 		if("Sleek")
 			R.icon = 'austation/icons/mob/robot.dmi'
 			cyborg_base_icon = "sleekmin"
+			hat_offset = -1
 		// austation end
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Defines hat_offset for the new borg sprites that got ported earlier this week.

## Why It's Good For The Game

Stops floating hats.

## Changelog
:cl:
fix: Defines hat_offset on the new sprites
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
