### PR TITLE
Removes skewium from possible bounties

### DIFF
--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -175,7 +175,6 @@
 		/datum/reagent/consumable/frostoil,\
 		/datum/reagent/toxin/slimejelly,\
 		/datum/reagent/teslium/energized_jelly,\
-		/datum/reagent/toxin/skewium,\
 		/datum/reagent/toxin/mimesbane,\
 		/datum/reagent/medicine/strange_reagent,\
 		/datum/reagent/nitroglycerin,\

--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -175,6 +175,7 @@
 		/datum/reagent/consumable/frostoil,\
 		/datum/reagent/toxin/slimejelly,\
 		/datum/reagent/teslium/energized_jelly,\
+		// /datum/reagent/toxin/skewium,\ austation -- removes skewium from possible bounties
 		/datum/reagent/toxin/mimesbane,\
 		/datum/reagent/medicine/strange_reagent,\
 		/datum/reagent/nitroglycerin,\

--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -175,7 +175,7 @@
 		/datum/reagent/consumable/frostoil,\
 		/datum/reagent/toxin/slimejelly,\
 		/datum/reagent/teslium/energized_jelly,\
-		// /datum/reagent/toxin/skewium,\ austation -- removes skewium from possible bounties
+// 		/datum/reagent/toxin/skewium,\ austation -- removes skewium from possible bounties
 		/datum/reagent/toxin/mimesbane,\
 		/datum/reagent/medicine/strange_reagent,\
 		/datum/reagent/nitroglycerin,\


### PR DESCRIPTION


## About The Pull Request

titles

## Why It's Good For The Game

Skewium was removed from the game here, making this bounty impossible to complete

## Changelog
:cl:
del: Prevents skewium from becoming a reagent bounty
/:cl:

