### PR TITLE
Dead mobs no longer spawn split-personality and imaginary friends

### DIFF
--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -43,6 +43,11 @@
 
 /datum/brain_trauma/special/imaginary_friend/proc/get_ghost()
 	set waitfor = FALSE
+	// austation begin -- oh yes I too enjoy becoming the imaginary friend of some dead clown on lavaland
+	if(owner.stat == DEAD)
+		qdel(src)
+		return
+	// austation end
 	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as [owner]'s imaginary friend?", ROLE_PAI, null, null, 75, friend, POLL_IGNORE_IMAGINARYFRIEND)
 	if(LAZYLEN(candidates))
 		var/mob/dead/observer/C = pick(candidates)

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -23,6 +23,11 @@
 
 /datum/brain_trauma/severe/split_personality/proc/get_ghost()
 	set waitfor = FALSE
+	// austation begin -- oh yes I too enjoy becoming the split personality of some dead clown on lavaland
+	if(owner.stat == DEAD)
+		qdel(src)
+		return
+	// ausation end
 	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as [owner]'s split personality?", ROLE_PAI, null, null, 75, stranger_backseat, POLL_IGNORE_SPLITPERSONALITY)
 	if(LAZYLEN(candidates))
 		var/mob/dead/observer/C = pick(candidates)


### PR DESCRIPTION
## About The Pull Request
I get ahelps about this constantly of people who get spawned as split-personality or imaginary friend of random dead NPCs on lavaland or in space, or even long dead players thanks to organ decay (thanks, cobbymed! /s). Now dead mobs are excluded from getting these traumas.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fix good, less pointless ahelps
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: dead mobs no longer trigger ghostrole traumas
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
