### PR TITLE
Laser pointer re-balance

### DIFF
--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -11,9 +11,9 @@
 	materials = list(/datum/material/iron=500, /datum/material/glass=500)
 	w_class = WEIGHT_CLASS_SMALL
 	var/turf/pointer_loc
-	var/energy = 5
-	var/max_energy = 5
-	var/effectchance = 33
+	var/energy = 6	\\Austation changed from 5 to 6
+	var/max_energy = 6 \\Austation changed from 5 to 6
+	var/effectchance = 35 \\Austation changed from 33 to 35
 	var/recharging = 0
 	var/recharge_locked = FALSE
 	var/obj/item/stock_parts/micro_laser/diode //used for upgrading!

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -11,9 +11,9 @@
 	materials = list(/datum/material/iron=500, /datum/material/glass=500)
 	w_class = WEIGHT_CLASS_SMALL
 	var/turf/pointer_loc
-	var/energy = 6	\\Austation changed from 5 to 6
-	var/max_energy = 6 \\Austation changed from 5 to 6
-	var/effectchance = 35 \\Austation changed from 33 to 35
+	var/energy = 6	//Austation changed from 5 to 6
+	var/max_energy = 6 //Austation changed from 5 to 6
+	var/effectchance = 35 //Austation changed from 33 to 35
 	var/recharging = 0
 	var/recharge_locked = FALSE
 	var/obj/item/stock_parts/micro_laser/diode //used for upgrading!
@@ -121,7 +121,7 @@
 		//chance to actually hit the eyes depends on internal component
 		if(prob(effectchance * diode.rating))
 			S.flash_act(affect_silicon = 1)
-			\\different values on austation original values are rand(100,200)
+			//different values on austation original values are rand(100,200)
 			S.Paralyze(rand(1 * diode.rating, 2 * diode.rating))
 			to_chat(S, "<span class='danger'>Your sensors were overloaded by a laser!</span>")
 			outmsg = "<span class='notice'>You overload [S] by shining [src] at [S.p_their()] sensors.</span>"

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -122,7 +122,7 @@
 		if(prob(effectchance * diode.rating))
 			S.flash_act(affect_silicon = 1)
 			//different values on austation original values are rand(100,200)
-			S.Paralyze(rand(1 * diode.rating, 2 * diode.rating))
+			S.Paralyze(rand(10 * diode.rating, 20 * diode.rating))
 			to_chat(S, "<span class='danger'>Your sensors were overloaded by a laser!</span>")
 			outmsg = "<span class='notice'>You overload [S] by shining [src] at [S.p_their()] sensors.</span>"
 		else

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -121,7 +121,8 @@
 		//chance to actually hit the eyes depends on internal component
 		if(prob(effectchance * diode.rating))
 			S.flash_act(affect_silicon = 1)
-			S.Paralyze(rand(100,200))
+			\\different values on austation original values are rand(100,200)
+			S.Paralyze(rand(1 * diode.rating, 2 * diode.rating))
 			to_chat(S, "<span class='danger'>Your sensors were overloaded by a laser!</span>")
 			outmsg = "<span class='notice'>You overload [S] by shining [src] at [S.p_their()] sensors.</span>"
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reduces the paralyse time on silicons significantly and slightly increases the amount of charges and chance to hit/effect. 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

A flash gives 7 seconds of paralyse.
The laser pointer was giving 10-20 seconds.

A robotics flash has 4 charges.
The laser pointer had 5.

A flash forces you to be adjacent to to your target.
The laser pointer can do it at range.

I feel like the laser pointer was quite overpowered and it has been reduced to something that can give you an edge instead of being the key in a silicon fight.

## Changelog
:cl:
balance: Changed Laser pointer to paralyse for a much shorter time than before.
balance: Increased the amount of charges a Laser pointer had by 1
balance: Increased the effectchance variable from 33 to 35
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
