### PR TITLE
Adds holofan to engineering borgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -286,6 +286,7 @@
 		/obj/item/construction/rcd/borg,
 		/obj/item/pipe_dispenser,
 		/obj/item/extinguisher,
+		/obj/item/holosign_creator/atmos, // austation -- adds holofan
 		/obj/item/weldingtool/largetank/cyborg,
 		/obj/item/screwdriver/cyborg,
 		/obj/item/wrench/cyborg,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds atmos holofan to engineering borgs.
This is also a copy of my upstream PR ( https://github.com/BeeStation/BeeStation-Hornet/pull/2045 ) because im impatient.

## Why It's Good For The Game

Fastmos is very dangerous and engineering borgs dont have the best tool used to deal with atmos hazards.

## Changelog
:cl:
add: Engineering borgs now have atmos holofans
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
