### PR TITLE
Nitryl Stim Buff Reconfigure

### DIFF
--- a/austation/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/austation/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -53,14 +53,6 @@
 	max_brightness = 6
 	power = 1.8
 
-/datum/reagent/nitryloxide
-	name = "Nitryl Oxide"
-	description = "A highly reactive stimulant and anaesthetic."
-	reagent_state = GAS
-	metabolization_rate = REAGENTS_METABOLISM * 0.5 // Because stimulum/nitryl are handled through gas breathing, metabolism must be lower for breathcode to keep up
-	color = "90560B"
-	taste_description = "fruity"
-
 /datum/reagent/stimulum/on_mob_metabolize(mob/living/L)
 	..()
 	L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=-1, blacklisted_movetypes=(FLYING|FLOATING))

--- a/austation/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/austation/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -52,3 +52,32 @@
 	power_coefficient = 5 // 30 units to reach max brightness
 	max_brightness = 6
 	power = 1.8
+
+/datum/reagent/nitryloxide
+	name = "Nitryl Oxide"
+	description = "A highly reactive stimulant and anaesthetic."
+	reagent_state = GAS
+	metabolization_rate = REAGENTS_METABOLISM * 0.5 // Because stimulum/nitryl are handled through gas breathing, metabolism must be lower for breathcode to keep up
+	color = "90560B"
+	taste_description = "fruity"
+
+/datum/reagent/stimulum/on_mob_metabolize(mob/living/L)
+	..()
+	L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=-1, blacklisted_movetypes=(FLYING|FLOATING))
+	ADD_TRAIT(L, TRAIT_IGNORESLOWDOWN, type)
+
+/datum/reagent/stimulum/on_mob_end_metabolize(mob/living/L)
+	L.remove_movespeed_modifier(type)
+	REMOVE_TRAIT(L, TRAIT_IGNORESLOWDOWN, type)
+	..()
+
+
+/datum/reagent/nitryloxide/on_mob_metabolize(mob/living/L)
+	..()
+	ADD_TRAIT(L, TRAIT_IGNOREDAMAGESLOWDOWN, type)
+	ADD_TRAIT(L, TRAIT_IGNORESLOWDOWN, type)
+
+/datum/reagent/nitryloxide/on_mob_end_metabolize(mob/living/L)
+	REMOVE_TRAIT(L, TRAIT_IGNOREDAMAGESLOWDOWN, type)
+	REMOVE_TRAIT(L, TRAIT_IGNORESLOWDOWN, type)
+		..()

--- a/austation/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/austation/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -71,12 +71,20 @@
 	REMOVE_TRAIT(L, TRAIT_IGNORESLOWDOWN, type)
 	..()
 
-/datum/reagent/nitryloxide/on_mob_metabolize(mob/living/L)
-	..()
+/datum/reagent/nitryl/on_mob_metabolize(mob/living/L)
 	ADD_TRAIT(L, TRAIT_IGNOREDAMAGESLOWDOWN, type)
 	ADD_TRAIT(L, TRAIT_IGNORESLOWDOWN, type)
 
-/datum/reagent/nitryloxide/on_mob_end_metabolize(mob/living/L)
+/datum/reagent/nitryl/on_mob_life(mob/living/L)
+	if(L.reagents.get_reagent_amount(/datum/reagent/nitryl) > 1)
+		L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=-1, blacklisted_movetypes=(FLYING|FLOATING))
+	else if(L.remove_movespeed_modifier(type))
+		L.remove_movespeed_modifier(type)
+	..()
+
+/datum/reagent/nitryl/on_mob_end_metabolize(mob/living/L)
 	REMOVE_TRAIT(L, TRAIT_IGNOREDAMAGESLOWDOWN, type)
 	REMOVE_TRAIT(L, TRAIT_IGNORESLOWDOWN, type)
-	..()
+
+	if(L.remove_movespeed_modifier(type))
+		L.remove_movespeed_modifier(type)

--- a/austation/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/austation/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -79,4 +79,4 @@
 /datum/reagent/nitryloxide/on_mob_end_metabolize(mob/living/L)
 	REMOVE_TRAIT(L, TRAIT_IGNOREDAMAGESLOWDOWN, type)
 	REMOVE_TRAIT(L, TRAIT_IGNORESLOWDOWN, type)
-		..()
+	..()

--- a/austation/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/austation/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -71,7 +71,6 @@
 	REMOVE_TRAIT(L, TRAIT_IGNORESLOWDOWN, type)
 	..()
 
-
 /datum/reagent/nitryloxide/on_mob_metabolize(mob/living/L)
 	..()
 	ADD_TRAIT(L, TRAIT_IGNOREDAMAGESLOWDOWN, type)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -257,10 +257,12 @@
 		var/tritium_partialpressure = (breath.get_moles(/datum/gas/tritium)/breath.total_moles())*breath_pressure
 		radiation += tritium_partialpressure/10
 
+		/*Bee nitryl
 	//NITRYL
 	if(breath.get_moles(/datum/gas/nitryl))
 		var/nitryl_partialpressure = (breath.get_moles(/datum/gas/nitryl)/breath.total_moles())*breath_pressure
 		adjustFireLoss(nitryl_partialpressure/4)
+		Bee nitryl end*/
 
 	//MIASMA
 	if(breath.get_moles(/datum/gas/miasma))

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -257,12 +257,12 @@
 		var/tritium_partialpressure = (breath.get_moles(/datum/gas/tritium)/breath.total_moles())*breath_pressure
 		radiation += tritium_partialpressure/10
 
-		/*Bee nitryl
+	/*bee station begin
 	//NITRYL
 	if(breath.get_moles(/datum/gas/nitryl))
 		var/nitryl_partialpressure = (breath.get_moles(/datum/gas/nitryl)/breath.total_moles())*breath_pressure
 		adjustFireLoss(nitryl_partialpressure/4)
-		Bee nitryl end*/
+	bee station end*/
 
 	//MIASMA
 	if(breath.get_moles(/datum/gas/miasma))

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -257,12 +257,12 @@
 		var/tritium_partialpressure = (breath.get_moles(/datum/gas/tritium)/breath.total_moles())*breath_pressure
 		radiation += tritium_partialpressure/10
 
-	/*bee station begin
+	/*removed beestation code begin -- removed in pull #1953
 	//NITRYL
 	if(breath.get_moles(/datum/gas/nitryl))
 		var/nitryl_partialpressure = (breath.get_moles(/datum/gas/nitryl)/breath.total_moles())*breath_pressure
 		adjustFireLoss(nitryl_partialpressure/4)
-	bee station end*/
+	removed beestation code end*/
 
 	//MIASMA
 	if(breath.get_moles(/datum/gas/miasma))

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -282,9 +282,10 @@
 		breath.adjust_moles(/datum/gas/nitryl, -gas_breathed)
 		removed beestation code end*/
 
-			//austation begin
+			//austation begin -- added in pull #1953
   // Nitryl
 			var/nitryl_pp = breath.get_breath_partial_pressure(breath.get_moles(/datum/gas/nitryl))
+
 			if (nitryl_pp > 40)
 				H.emote("gasp")
 				H.adjustFireLoss(10)
@@ -293,15 +294,19 @@
 					H.silent = max(H.silent, 3)
 
 			gas_breathed = breath.get_moles(/datum/gas/nitryl)
+			var/existingnitryl = H.reagents.get_reagent_amount(/datum/reagent/nitryl)
+			var/nitryllevel = 0
 
 			if (gas_breathed > gas_stimulation_min)
-				var/existingnitryloxide = H.reagents.get_reagent_amount(/datum/reagent/nitryloxide)
-				H.reagents.add_reagent(/datum/reagent/nitryloxide,max(0, 1 - existingnitryloxide))
-
+				nitryllevel = 1
 				if(nitryl_pp > 20)
-					var/existingnitryl = H.reagents.get_reagent_amount(/datum/reagent/nitryl)
-					H.reagents.add_reagent(/datum/reagent/nitryl,max(0, 1 - existingnitryl))
+					nitryllevel = 2
 					H.adjustFireLoss(nitryl_pp/4)
+
+				H.reagents.add_reagent(/datum/reagent/nitryl,max(0, nitryllevel - existingnitryl))
+
+			else if(existingnitryl > 0)
+				H.reagents.remove_reagent(/datum/reagent/nitryl, existingnitryl)
 
 			breath.adjust_moles(/datum/gas/nitryl, -gas_breathed)
 			//austation end

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -262,7 +262,7 @@
 		else
 			H.radiation += trit_pp/10
 
-		/*beestation begin
+		/*removed beestation code begin -- removed in pull #1953
 	// Nitryl
 		var/nitryl_pp = breath.get_breath_partial_pressure(breath.get_moles(/datum/gas/nitryl))
 		if (prob(nitryl_pp))
@@ -280,7 +280,7 @@
 			H.reagents.add_reagent(/datum/reagent/nitryl,1)
 
 		breath.adjust_moles(/datum/gas/nitryl, -gas_breathed)
-		beestation end*/
+		removed beestation code end*/
 
 			//austation begin
   // Nitryl

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -262,7 +262,7 @@
 		else
 			H.radiation += trit_pp/10
 
-			/*Bee nitryl
+		/*beestation begin
 	// Nitryl
 		var/nitryl_pp = breath.get_breath_partial_pressure(breath.get_moles(/datum/gas/nitryl))
 		if (prob(nitryl_pp))
@@ -280,9 +280,9 @@
 			H.reagents.add_reagent(/datum/reagent/nitryl,1)
 
 		breath.adjust_moles(/datum/gas/nitryl, -gas_breathed)
-		Bee nitryl end*/
+		beestation end*/
 
-		//AUStation Code Start
+			//austation begin
   // Nitryl
 			var/nitryl_pp = breath.get_breath_partial_pressure(breath.get_moles(/datum/gas/nitryl))
 			if (nitryl_pp > 40)
@@ -304,7 +304,7 @@
 					H.adjustFireLoss(nitryl_pp/4)
 
 			breath.adjust_moles(/datum/gas/nitryl, -gas_breathed)
-			//AUStation Code End
+			//austation end
 
 	// Stimulum
 		gas_breathed = breath.get_moles(/datum/gas/stimulum)

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -262,6 +262,7 @@
 		else
 			H.radiation += trit_pp/10
 
+			/*Bee nitryl
 	// Nitryl
 		var/nitryl_pp = breath.get_breath_partial_pressure(breath.get_moles(/datum/gas/nitryl))
 		if (prob(nitryl_pp))
@@ -279,6 +280,31 @@
 			H.reagents.add_reagent(/datum/reagent/nitryl,1)
 
 		breath.adjust_moles(/datum/gas/nitryl, -gas_breathed)
+		Bee nitryl end*/
+
+		//AUStation Code Start
+  // Nitryl
+			var/nitryl_pp = breath.get_breath_partial_pressure(breath.get_moles(/datum/gas/nitryl))
+			if (nitryl_pp > 40)
+				H.emote("gasp")
+				H.adjustFireLoss(10)
+				if (prob(nitryl_pp/2))
+					to_chat(H, "<span class='alert'>Your throat closes up!</span>")
+					H.silent = max(H.silent, 3)
+
+			gas_breathed = breath.get_moles(/datum/gas/nitryl)
+
+			if (gas_breathed > gas_stimulation_min)
+				var/existingnitryloxide = H.reagents.get_reagent_amount(/datum/reagent/nitryloxide)
+				H.reagents.add_reagent(/datum/reagent/nitryloxide,max(0, 1 - existingnitryloxide))
+
+				if(nitryl_pp > 20)
+					var/existingnitryl = H.reagents.get_reagent_amount(/datum/reagent/nitryl)
+					H.reagents.add_reagent(/datum/reagent/nitryl,max(0, 1 - existingnitryl))
+					H.adjustFireLoss(nitryl_pp/4)
+
+			breath.adjust_moles(/datum/gas/nitryl, -gas_breathed)
+			//AUStation Code End
 
 	// Stimulum
 		gas_breathed = breath.get_moles(/datum/gas/stimulum)
@@ -450,4 +476,3 @@ obj/item/organ/lungs/apid
 	desc = "Lungs from an apid, or beeperson. Thanks to the many spiracles an apid has, these lungs are capable of gathering more oxygen from low-pressure enviroments."
 	icon_state = "lungs"
 	safe_oxygen_min = 8
-


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
_commissioned by Ohagi_
## About The Pull Request
**Nitryl below 20kPa**
user ignores encumbrance
user ignores damage slowdown
**Above 20kPa**
all of the above
kPa/4 burn damage
same old nitryl speed bonus

Stimulum has its speed buff back & ignores encumbrance

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Atmo has one of the hardest leanring curves in the game while having some of the worst incentives. This pull request is to bring the job progression up to the level of other jobs. This will actaully encourage people to actually use the gases. Have you ever seen anyone make nitryl or stim?

Purging chems disable the buffs so it's not as powerful as it seems on the outset.

The progression of these gasses is not out of line to the power progression of other jobs and it has counter play.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: buffed Nitryl & Stimulum 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->