### PR TITLE
Roos rebalance

### DIFF
--- a/austation/code/modules/mob/living/simple_animal/hostile/retaliate/kangaroo.dm
+++ b/austation/code/modules/mob/living/simple_animal/hostile/retaliate/kangaroo.dm
@@ -15,8 +15,13 @@
 	maxHealth = 150
 	health = 150
 	gold_core_spawnable = HOSTILE_SPAWN
+	blood_volume = BLOOD_VOLUME_NORMAL
 	harm_intent_damage = 3
-	melee_damage = 12
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab = 6)
+	melee_damage = 10
+	response_help  = "pets"
+	response_disarm = "gently pushes aside"
+	response_harm   = "punches"
 	attacktext = "slashes"
 	attack_sound = 'sound/weapons/bladeslice.ogg' // they have nails that work like claws, so, slashing sound
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 2, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
@@ -24,6 +29,8 @@
 	speed = -1 // '-1' converts to 1.5 total move delay, or 6.6 tiles/sec movespeed
 	var/attack_cycles = 0
 	var/attack_cycles_max = 3
+
+	do_footstep = TRUE
 
 /mob/living/simple_animal/hostile/retaliate/kangaroo/AttackingTarget()
 	var/mob/living/L = target
@@ -41,8 +48,7 @@
 	// ... but, every attack_cycles_max attacks on a living mob, do a powerful disemboweling kick instead
 	attack_cycles = 0
 	attacktext = "VICIOUSLY KICKS"
-	melee_damage = 60
-	melee_damage = 60
+	melee_damage = 30
 	. = ..()
 
 	var/rookick_dir = get_dir(src, L)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Kangaroo kicks now don't crit people after two kicks and roos are now gibbable for meat

## Why It's Good For The Game

roos too op pls nerf

## Changelog
:cl:
tweak: roo kicks deal less damage and roos are now butcherable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
