### PR TITLE
Drone quality of life improvement

### DIFF
--- a/austation/code/modules/mob/living/simple_animal/friendly/drone/drone.dm
+++ b/austation/code/modules/mob/living/simple_animal/friendly/drone/drone.dm
@@ -1,0 +1,11 @@
+/mob/living/simple_animal/drone/RangedAttack(atom/A, mouseparams)
+	. = ..()
+
+	if(isturf(A) && get_dist(src,A) <= 1)
+		src.Move_Pulled(A)
+		return
+
+/mob/living/simple_animal/drone/get_jetpack()
+	var/obj/item/tank/jetpack/J = internal_storage
+	if(istype(J))
+		return J

--- a/austation/code/modules/mob/living/simple_animal/friendly/drone/drone_movement.dm
+++ b/austation/code/modules/mob/living/simple_animal/friendly/drone/drone_movement.dm
@@ -1,0 +1,9 @@
+/mob/living/simple_animal/drone/Process_Spacemove(movement_dir = 0)
+	if(..())
+		return 1
+	if(!isturf(loc))
+		return 0
+
+	var/obj/item/tank/jetpack/J = get_jetpack()
+	if(istype(J) && (movement_dir || J.stabilizers) && J.allow_thrust(0.01, src))
+		return 1

--- a/austation/code/modules/mob/living/simple_animal/friendly/drone/emote.dm
+++ b/austation/code/modules/mob/living/simple_animal/friendly/drone/emote.dm
@@ -1,0 +1,2 @@
+/datum/emote/silicon
+	mob_type_allowed_typecache = list(/mob/living/silicon, /mob/living/simple_animal/drone, /mob/living/simple_animal/bot) // And comp said "Let all silicon be equal"

--- a/austation/includes.dm
+++ b/austation/includes.dm
@@ -94,3 +94,6 @@
 #include "code\modules\vending\wardrobes.dm"
 #include "code\modules\atmospherics\machinery\atmosmachinery.dm"
 #include "code\modules\atmospherics\machinery\components\unary_devices\thermomachine.dm"
+#include "code\modules\mob\living\simple_animal\friendly\drone\drone.dm"
+#include "code\modules\mob\living\simple_animal\friendly\drone\drone_movement.dm"
+#include "code\modules\mob\living\simple_animal\friendly\drone\emote.dm"

--- a/austation/includes.dm
+++ b/austation/includes.dm
@@ -73,6 +73,9 @@
 #include "code\modules\mob\living\silicon\robot\emote.dm"
 #include "code\modules\mob\living\silicon\robot\robot_modules.dm"
 #include "code\modules\mob\living\simple_animal\bot\deathsky.dm"
+#include "code\modules\mob\living\simple_animal\friendly\drone\drone.dm"
+#include "code\modules\mob\living\simple_animal\friendly\drone\drone_movement.dm"
+#include "code\modules\mob\living\simple_animal\friendly\drone\emote.dm"
 #include "code\modules\mob\living\simple_animal\hostile\cat_butcher.dm"
 #include "code\modules\mob\living\simple_animal\hostile\retaliate\kangaroo.dm"
 #include "code\modules\reagents\chemistry\reagents\other_reagents.dm"
@@ -94,6 +97,4 @@
 #include "code\modules\vending\wardrobes.dm"
 #include "code\modules\atmospherics\machinery\atmosmachinery.dm"
 #include "code\modules\atmospherics\machinery\components\unary_devices\thermomachine.dm"
-#include "code\modules\mob\living\simple_animal\friendly\drone\drone.dm"
-#include "code\modules\mob\living\simple_animal\friendly\drone\drone_movement.dm"
-#include "code\modules\mob\living\simple_animal\friendly\drone\emote.dm"
+

--- a/austation/includes.dm
+++ b/austation/includes.dm
@@ -97,4 +97,3 @@
 #include "code\modules\vending\wardrobes.dm"
 #include "code\modules\atmospherics\machinery\atmosmachinery.dm"
 #include "code\modules\atmospherics\machinery\components\unary_devices\thermomachine.dm"
-


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

After banging my head against a brick wall I've decided to put the map port aside and make this: A small update to yah boi the drones. This includes a couple of simple additions. Drones can now push and pull items to specific turf by clicking said turf, similar to how humans can. Drones can now use jetpacks equipped in their equipment slot. Drones (And simple bots!) can now use silicon emotes, such as ping, buzz, chime, e.t.c.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Drones are sorely unloved. These changes are mostly quality of life and make a drones life a tad bit easier. Also means I won't have to worry about map merging and TGui for a bit longer.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Drones can now push pulled items onto turfs by clicking said turfs (similar to humans)
add: Drones can now use jetpacks!
add: Drones (and simple bots) can use silicon emotes (such as buzz, ping and chime)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
