### PR TITLE
Makes the advanced cautery small sized

### DIFF
--- a/austation/code/modules/surgery/tools.dm
+++ b/austation/code/modules/surgery/tools.dm
@@ -1,0 +1,2 @@
+/obj/item/surgicaldrill/advanced
+	w_class = WEIGHT_CLASS_SMALL

--- a/austation/includes.dm
+++ b/austation/includes.dm
@@ -89,6 +89,7 @@
 #include "code\modules\research\designs\mechfabricator_designs.dm"
 #include "code\modules\research\designs\medical_designs.dm"
 #include "code\modules\surgery\organs\tongue.dm"
+#include "code\modules\surgery\tools.dm"
 #include "code\modules\uplink\uplink_items.dm"
 #include "code\modules\vehicles\cars\thanoscar.dm"
 #include "code\modules\pool\pool_controller.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title

## Why It's Good For The Game

it fits in the bluespace belt now and advanced tools should be smaller and better

## Changelog
:cl:
tweak: tweaked the advanced cautery's size
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
