### PR TITLE
Drained pools now paralyse borgs

### DIFF
--- a/austation/code/modules/pool/pool_main.dm
+++ b/austation/code/modules/pool/pool_main.dm
@@ -153,15 +153,15 @@
 				if(!filled)
 					var/mob/living/silicon/robot/R = victim
 					if(prob(75))
-						R.Paralyze(75)
+						R.Paralyze(5)
 						R.apply_damage(7, BRUTE)
 						R.visible_message("<span class='danger'>[R] falls in the drained pool!</span>",
 													"<span class='userdanger'>You fall in the drained pool!</span>")
 					else
-						R.Paralyze(200) //bad silicon, no powercreep
+						R.Paralyze(15) //bad silicon, no powercreep
 						R.apply_damage(15, BRUTE)
-						R.visible_message("<span class='danger'>[R] falls in the drained pool and hits their module hard!</span>",
-													"<span class='userdanger'>You fall in the drained pool hard!</span>")
+						R.visible_message("<span class='danger'>[R] falls in the drained pool, and hits their gyroscopic module!</span>",
+													"<span class='userdanger'>You fall in the drained pool, and hit your gyroscopic module!</span>")
 		else if(filled)
 			playsound(src, "water_wade", 20, TRUE)
 	return ..()

--- a/austation/code/modules/pool/pool_main.dm
+++ b/austation/code/modules/pool/pool_main.dm
@@ -149,6 +149,19 @@
 										"<span class='userdanger'>You fall in the drained pool, but you had an helmet!</span>")
 					H.Knockdown(40)
 					playsound(src, 'sound/effects/woodhit.ogg', 60, TRUE, 1)
+			if(issilicon(AM))
+				if(!filled)
+					var/mob/living/silicon/robot/R = victim
+					if(prob(75))
+						R.Paralyze(75)
+						R.apply_damage(7, BRUTE)
+						R.visible_message("<span class='danger'>[R] falls in the drained pool!</span>",
+													"<span class='userdanger'>You fall in the drained pool!</span>")
+					else
+						R.Paralyze(200) //bad silicon, no powercreep
+						R.apply_damage(15, BRUTE)
+						R.visible_message("<span class='danger'>[R] falls in the drained pool and hits their module hard!</span>",
+													"<span class='userdanger'>You fall in the drained pool hard!</span>")
 		else if(filled)
 			playsound(src, "water_wade", 20, TRUE)
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

borgs can permastun people in the pools when it's drained it so I made them get stunned when they fall in too

## Why It's Good For The Game

cringe borgs

## Changelog
:cl:
tweak: Drained pools now also paralyse borgs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
