### PR TITLE
Xenobiology crates

### DIFF
--- a/austation/code/modules/cargo/packs.dm
+++ b/austation/code/modules/cargo/packs.dm
@@ -16,7 +16,6 @@
               /obj/item/slime_extract/orange,
               /obj/item/slime_extract/grey,
               /obj/item/slime_extract/grey)
-
 	crate_name = "xenobiology common crate"
 	crate_type = /obj/structure/closet/crate/secure/science
 
@@ -34,7 +33,6 @@
 			  /obj/item/slime_extract/silver,
 			  /obj/item/slime_extract/gold,
 			  /obj/item/slime_extract/red)
-
 	crate_name = "xenobiology intermediate crate"
 	crate_type = /obj/structure/closet/crate/secure/science
 
@@ -52,6 +50,5 @@
 			  /obj/item/slime_extract/lightpink,
 			  /obj/item/slime_extract/pyrite,
 			  /obj/item/slime_extract/adamantine)
-
 	crate_name = "xenobiology advanced crate"
 	crate_type = /obj/structure/closet/crate/secure/science

--- a/austation/code/modules/cargo/packs.dm
+++ b/austation/code/modules/cargo/packs.dm
@@ -1,6 +1,5 @@
 //Science
 
-
 /datum/supply_pack/science/xenobiology_common
 	name = "Xenobiology Crate (Common)"
 	desc = "A crate filled with 10 common core extracts, for use by the science team"
@@ -38,7 +37,6 @@
 
 	crate_name = "xenobiology intermediate crate"
 	crate_type = /obj/structure/closet/crate/secure/science
-
 
 /datum/supply_pack/science/xenobiology_advanced
 	name = "Xenobiology Crate (Advanced)"

--- a/austation/code/modules/cargo/packs.dm
+++ b/austation/code/modules/cargo/packs.dm
@@ -13,22 +13,22 @@
               /obj/item/slime_extract/orange,
               /obj/item/slime_extract/grey,
 
-              if (prob)(60))
+			if (prob)(60))
                 /obj/item/slime_extract/metal,
               else
                 /obj/item/slime_extract/grey,
 
-               if (prob)(60))
+			if (prob)(60))
                 /obj/item/slime_extract/purple,
               else
                 /obj/item/slime_extract/grey,
 
-               if (prob)(60))
+			if (prob)(60))
                 /obj/item/slime_extract/blue,
               else
                 /obj/item/slime_extract/grey,
 
-               if (prob)(60))
+			if (prob)(60))
                 /obj/item/slime_extract/orange,
               else
                 /obj/item/slime_extract/grey,)

--- a/austation/code/modules/cargo/packs.dm
+++ b/austation/code/modules/cargo/packs.dm
@@ -62,5 +62,5 @@
 	              /obj/item/slime_extract/grey,
 	              /obj/item/slime_extract/grey,
 	              /obj/item/slime_extract/grey,
-	              /obj/item/slime_extract/grey,)
+	              /obj/item/slime_extract/grey)
 	crate_name = "Smuggled slime core crate"

--- a/austation/code/modules/cargo/packs.dm
+++ b/austation/code/modules/cargo/packs.dm
@@ -1,0 +1,37 @@
+//Science
+
+
+/datum/supply_pack/science/xenobiology_common
+	name = "Xenobiology Crate (Common)"
+	desc = "A crate filled with 10 common core extracts, for use by the science team"
+	cost = 5500
+	access = ACCESS_SCIENCE
+	contains = list(
+              /obj/item/slime_extract/metal,
+              /obj/item/slime_extract/purple,
+              /obj/item/slime_extract/blue,
+              /obj/item/slime_extract/orange,
+              /obj/item/slime_extract/grey,
+
+              if (prob)(60))
+                /obj/item/slime_extract/metal,
+              else
+                /obj/item/slime_extract/grey,
+
+               if (prob)(60))
+                /obj/item/slime_extract/purple,
+              else
+                /obj/item/slime_extract/grey,
+
+               if (prob)(60))
+                /obj/item/slime_extract/blue,
+              else
+                /obj/item/slime_extract/grey,
+
+               if (prob)(60))
+                /obj/item/slime_extract/orange,
+              else
+                /obj/item/slime_extract/grey,)
+
+	crate_name = "robotics assembly crate"
+	crate_type = /obj/structure/closet/crate/secure/science

--- a/austation/code/modules/cargo/packs.dm
+++ b/austation/code/modules/cargo/packs.dm
@@ -53,3 +53,22 @@
 
 	crate_name = "xenobiology intermediate crate"
 	crate_type = /obj/structure/closet/crate/secure/science
+
+
+/datum/supply_pack/science/xenobiology_advanced
+	name = "Xenobiology Crate (Advanced)"
+	desc = "A crate filled with 8 advanced core extracts, for use by the science team"
+	cost = 25000
+	access = ACCESS_SCIENCE
+	contains = list(
+              /obj/item/slime_extract/bluespace,
+              /obj/item/slime_extract/oil,
+              /obj/item/slime_extract/sepia,
+              /obj/item/slime_extract/black,
+              /obj/item/slime_extract/cerulean,
+			  /obj/item/slime_extract/lightpink,
+			  /obj/item/slime_extract/pyrite,
+			  /obj/item/slime_extract/adamantine)
+
+	crate_name = "xenobiology advanced crate"
+	crate_type = /obj/structure/closet/crate/secure/science

--- a/austation/code/modules/cargo/packs.dm
+++ b/austation/code/modules/cargo/packs.dm
@@ -5,7 +5,7 @@
 	name = "Xenobiology Crate (Common)"
 	desc = "A crate filled with 9 common core extracts, for use by the science team"
 	cost = 5500
-	access = ACCESS_SCIENCE
+	access = ACCESS_TOX_STORAGE
 	contains = list(
               /obj/item/slime_extract/metal,
               /obj/item/slime_extract/purple,
@@ -40,7 +40,7 @@
 	name = "Xenobiology Crate (Intermidiate)"
 	desc = "A crate filled with 8 intermediate core extracts, for use by the science team"
 	cost = 10700
-	access = ACCESS_SCIENCE
+	access = ACCESS_TOX_STORAGE
 	contains = list(
               /obj/item/slime_extract/yellow,
               /obj/item/slime_extract/darkpurple,
@@ -59,7 +59,7 @@
 	name = "Xenobiology Crate (Advanced)"
 	desc = "A crate filled with 8 advanced core extracts, for use by the science team"
 	cost = 25000
-	access = ACCESS_SCIENCE
+	access = ACCESS_TOX_STORAGE
 	contains = list(
               /obj/item/slime_extract/bluespace,
               /obj/item/slime_extract/oil,

--- a/austation/code/modules/cargo/packs.dm
+++ b/austation/code/modules/cargo/packs.dm
@@ -13,22 +13,22 @@
               /obj/item/slime_extract/orange,
               /obj/item/slime_extract/grey,
 
-			if (prob)(60))
+			if(prob)(60))
                 /obj/item/slime_extract/metal,
               else
                 /obj/item/slime_extract/grey,
 
-			if (prob)(60))
+			if(prob)(60))
                 /obj/item/slime_extract/purple,
               else
                 /obj/item/slime_extract/grey,
 
-			if (prob)(60))
+			if(prob)(60))
                 /obj/item/slime_extract/blue,
               else
                 /obj/item/slime_extract/grey,
 
-			if (prob)(60))
+			if(prob)(60))
                 /obj/item/slime_extract/orange,
               else
                 /obj/item/slime_extract/grey,)

--- a/austation/code/modules/cargo/packs.dm
+++ b/austation/code/modules/cargo/packs.dm
@@ -33,5 +33,5 @@
               else
                 /obj/item/slime_extract/grey,)
 
-	crate_name = "robotics assembly crate"
+	crate_name = "xenobiology common crate"
 	crate_type = /obj/structure/closet/crate/secure/science

--- a/austation/code/modules/cargo/packs.dm
+++ b/austation/code/modules/cargo/packs.dm
@@ -13,22 +13,22 @@
               /obj/item/slime_extract/orange,
               /obj/item/slime_extract/grey,
 
-			if(prob)(60))
+			if(prob(60))
                 /obj/item/slime_extract/metal,
               else
                 /obj/item/slime_extract/grey,
 
-			if(prob)(60))
+			if(prob(60))
                 /obj/item/slime_extract/purple,
               else
                 /obj/item/slime_extract/grey,
 
-			if(prob)(60))
+			if(prob(60))
                 /obj/item/slime_extract/blue,
               else
                 /obj/item/slime_extract/grey,
 
-			if(prob)(60))
+			if(prob(60))
                 /obj/item/slime_extract/orange,
               else
                 /obj/item/slime_extract/grey,)

--- a/austation/code/modules/cargo/packs.dm
+++ b/austation/code/modules/cargo/packs.dm
@@ -3,7 +3,7 @@
 
 /datum/supply_pack/science/xenobiology_common
 	name = "Xenobiology Crate (Common)"
-	desc = "A crate filled with 10 common core extracts, for use by the science team"
+	desc = "A crate filled with 9 common core extracts, for use by the science team"
 	cost = 5500
 	access = ACCESS_SCIENCE
 	contains = list(

--- a/austation/code/modules/cargo/packs.dm
+++ b/austation/code/modules/cargo/packs.dm
@@ -3,35 +3,20 @@
 
 /datum/supply_pack/science/xenobiology_common
 	name = "Xenobiology Crate (Common)"
-	desc = "A crate filled with 9 common core extracts, for use by the science team"
-	cost = 5500
+	desc = "A crate filled with 10 common core extracts, for use by the science team"
+	cost = 6000
 	access = ACCESS_TOX_STORAGE
 	contains = list(
               /obj/item/slime_extract/metal,
+              /obj/item/slime_extract/metal,
+              /obj/item/slime_extract/purple,
               /obj/item/slime_extract/purple,
               /obj/item/slime_extract/blue,
+              /obj/item/slime_extract/blue,
+              /obj/item/slime_extract/orange,
               /obj/item/slime_extract/orange,
               /obj/item/slime_extract/grey,
-
-			if(prob(60))
-                /obj/item/slime_extract/metal,
-              else
-                /obj/item/slime_extract/grey,
-
-			if(prob(60))
-                /obj/item/slime_extract/purple,
-              else
-                /obj/item/slime_extract/grey,
-
-			if(prob(60))
-                /obj/item/slime_extract/blue,
-              else
-                /obj/item/slime_extract/grey,
-
-			if(prob(60))
-                /obj/item/slime_extract/orange
-              else
-                /obj/item/slime_extract/grey)
+              /obj/item/slime_extract/grey)
 
 	crate_name = "xenobiology common crate"
 	crate_type = /obj/structure/closet/crate/secure/science

--- a/austation/code/modules/cargo/packs.dm
+++ b/austation/code/modules/cargo/packs.dm
@@ -29,9 +29,27 @@
                 /obj/item/slime_extract/grey,
 
 			if(prob(60))
-                /obj/item/slime_extract/orange,
+                /obj/item/slime_extract/orange
               else
-                /obj/item/slime_extract/grey,)
+                /obj/item/slime_extract/grey)
 
 	crate_name = "xenobiology common crate"
+	crate_type = /obj/structure/closet/crate/secure/science
+
+/datum/supply_pack/science/xenobiology_intermediate
+	name = "Xenobiology Crate (Intermidiate)"
+	desc = "A crate filled with 8 intermediate core extracts, for use by the science team"
+	cost = 10700
+	access = ACCESS_SCIENCE
+	contains = list(
+              /obj/item/slime_extract/yellow,
+              /obj/item/slime_extract/darkpurple,
+              /obj/item/slime_extract/darkblue,
+              /obj/item/slime_extract/green,
+              /obj/item/slime_extract/pink,
+			  /obj/item/slime_extract/silver,
+			  /obj/item/slime_extract/gold,
+			  /obj/item/slime_extract/red)
+
+	crate_name = "xenobiology intermediate crate"
 	crate_type = /obj/structure/closet/crate/secure/science

--- a/austation/code/modules/cargo/packs.dm
+++ b/austation/code/modules/cargo/packs.dm
@@ -52,3 +52,15 @@
 			  /obj/item/slime_extract/adamantine)
 	crate_name = "xenobiology advanced crate"
 	crate_type = /obj/structure/closet/crate/secure/science
+
+/datum/supply_pack/science/xenobiology_illegal
+	name = "Smuggled slime core crate"
+	desc = "We found a few monkies holding these, would you have a use for them?"
+	cost = 3000
+	contraband = TRUE
+	contains = list(
+	              /obj/item/slime_extract/grey,
+	              /obj/item/slime_extract/grey,
+	              /obj/item/slime_extract/grey,
+	              /obj/item/slime_extract/grey,)
+	crate_name = "Smuggled slime core crate"

--- a/austation/code/modules/cargo/packs.dm
+++ b/austation/code/modules/cargo/packs.dm
@@ -55,12 +55,10 @@
 
 /datum/supply_pack/science/xenobiology_illegal
 	name = "Smuggled slime core crate"
-	desc = "We found a few monkies holding these, would you have a use for them?"
-	cost = 3000
+	desc = "Heya mate, these banging slime cores are explosive 'n shit, make sure not to fill them with plasma and hold them else your arm will fly off like a boomerang!"
+	cost = 6500
 	contraband = TRUE
 	contains = list(
-	              /obj/item/slime_extract/grey,
-	              /obj/item/slime_extract/grey,
-	              /obj/item/slime_extract/grey,
-	              /obj/item/slime_extract/grey)
+	              /obj/item/slime_extract/oil,
+	              /obj/item/slime_extract/oil)
 	crate_name = "Smuggled slime core crate"

--- a/austation/includes.dm
+++ b/austation/includes.dm
@@ -112,3 +112,4 @@
 #include "code\modules\atmospherics\machinery\components\unary_devices\thermomachine.dm"
 #include "code\modules\cargo\exports\food_and_drink\processed.dm"
 #include "code\modules\cargo\exports\organs.dm"
+#include "code\modules\cargo\packs.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so cargo can buy slime extracts for lots of money

## Why It's Good For The Game

The extracts allow you to do some cool things with slimes yet doesn't give you the power gaming of crossbreeds
also, sci has something to spend their budget on in order to get niche extracts if RNG is not in their favor

## Changelog
:cl:
add: adds Xenobiology crates to cargo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
