### PR TITLE
Nanite changes

### DIFF
--- a/code/modules/research/nanites/nanite_programs/sensor.dm
+++ b/code/modules/research/nanites/nanite_programs/sensor.dm
@@ -182,9 +182,11 @@
 	can_rule = TRUE
 	var/spent = FALSE
 
+//austation begin -- Adds brain damage and dermal damage (brute + burn) as a value that can be detected explicity
+#define DERMAL "dermal"
 /datum/nanite_program/sensor/damage/register_extra_settings()
 	. = ..()
-	extra_settings[NES_DAMAGE_TYPE] = new /datum/nanite_extra_setting/type(BRUTE, list(BRUTE, BURN, TOX, OXY, CLONE))
+	extra_settings[NES_DAMAGE_TYPE] = new /datum/nanite_extra_setting/type(BRUTE, list(BRUTE, BURN, TOX, OXY, CLONE, BRAIN, DERMAL))
 	extra_settings[NES_DAMAGE] = new /datum/nanite_extra_setting/number(50, 0, 500)
 	extra_settings[NES_DIRECTION] = new /datum/nanite_extra_setting/boolean(TRUE, "Above", "Below")
 
@@ -206,6 +208,10 @@
 			damage_amt = host_mob.getOxyLoss()
 		if(CLONE)
 			damage_amt = host_mob.getCloneLoss()
+		if(BRAIN)
+			damage_amt = host_mob.getOrganLoss(ORGAN_SLOT_BRAIN)
+		if(DERMAL)
+			damage_amt = host_mob.getBruteLoss() + host_mob.getFireLoss()
 
 	if(check_above)
 		if(damage_amt >= damage.get_value())
@@ -222,6 +228,8 @@
 	else
 		spent = FALSE
 		return FALSE
+#undef DERMAL
+//austation end
 
 /datum/nanite_program/sensor/damage/make_rule(datum/nanite_program/target)
 	var/datum/nanite_rule/damage/rule = new(target)

--- a/code/modules/research/nanites/nanite_programs/weapon.dm
+++ b/code/modules/research/nanites/nanite_programs/weapon.dm
@@ -50,9 +50,12 @@
 	rogue_types = list(/datum/nanite_program/necrotic)
 
 /datum/nanite_program/aggressive_replication/active_effect()
-	var/extra_regen = round(nanites.nanite_volume / 200, 0.1)
+//austation begin -- Organises brute and regen rates better, buffs the "extra regen" from being 200th of nanite volume to being 100th of nanite volume (doubles growth rate)
+	var/extra_regen = round(nanites.nanite_volume / 100, 0.1)
 	nanites.adjust_nanites(null, extra_regen)
-	host_mob.adjustBruteLoss(extra_regen / 2, TRUE)
+	var/brute_loss = round(nanites.nanite_volume / 200, 0.1)
+	host_mob.adjustBruteLoss(brute_loss, TRUE)
+//austation end
 
 /datum/nanite_program/meltdown
 	name = "Meltdown"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds just a couple of minor changes to nanites.

First off: Aggressive replication has been buffed. It now does double the damage and produces double the amount of nanites.
Secondly: The damage sensor has two new modes, "Brain" and "Dermal". Brain mode will detect when the brain has organ damage, as you'd expect. Dermal mode will use the sum of both brute and burn damage, useful with general healing programs such as bio-reconstruction and accelerated healing.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Buffs aggressive replication at the request of Holy Hiss. Complain to them if you have any issues.

The additional damage detection modes just add a handful more options to nanite programmers, and is useful when writing nanite software.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added "Brain" mode to nanite damage sensor programs, which detects brain damage
add: Added "Dermal" mode to nanite damage sensor programs, which detects the sum of brute and burn damage
balance: Doubled the nanite production and damage from the aggressive replication program
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
