### PR TITLE
Cat-ear tweak

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -13,7 +13,7 @@
 	clothing_flags = SNUG_FIT
 	flags_cover = HEADCOVERSEYES
 	flags_inv = HIDEHAIR
-	bang_protect = 1
+	bang_protect = 2
 
 	dog_fashion = /datum/dog_fashion/head/helmet
 

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -13,7 +13,7 @@
 	clothing_flags = SNUG_FIT
 	flags_cover = HEADCOVERSEYES
 	flags_inv = HIDEHAIR
-	bang_protect = 2
+	bang_protect = 1
 
 	dog_fashion = /datum/dog_fashion/head/helmet
 

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -94,7 +94,7 @@
 	icon = 'icons/obj/clothing/hats.dmi'
 	icon_state = "kitty"
 	damage_multiplier = 2 // austation -- keeps catgirl sensitive ears
-	bang_protect = -2
+	bang_protect = -1
 
 /obj/item/organ/ears/cat/Insert(mob/living/carbon/human/H, special = 0, drop_if_replaced = TRUE)
 	..()


### PR DESCRIPTION
@Coolsurf6 you are bad man, you drove me to this
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Coomsurf gay, security felinid now viable 

## Why It's Good For The Game

Felinid flashbang bullie sessions are now cancelled go home. (makes felinids who play security able to actually play security without getting flashbanged by both fellow sec, and people who somehow got flashbangs

## Changelog
:cl:
tweak: Changes cat ears bang protection from -2 to -1
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
