### PR TITLE
Xenobiology Steroid crate

### DIFF
--- a/austation/code/modules/cargo/packs.dm
+++ b/austation/code/modules/cargo/packs.dm
@@ -6,6 +6,6 @@
 	cost = 4500
 	access = ACCESS_TOXINS
 	contains = list(/obj/item/slimepotion/slime/steroid,
-                  /obj/item/slimepotion/slime/steroid)
+    				/obj/item/slimepotion/slime/steroid)
 	crate_name = "Xenobiology Slime Steroid crate"
 	crate_type = /obj/structure/closet/crate/secure/science

--- a/austation/code/modules/cargo/packs.dm
+++ b/austation/code/modules/cargo/packs.dm
@@ -4,7 +4,7 @@
 	name = "Xenobiology Mutagen crate"
 	desc = "Hate that one slime who won't stop mutating? Desperately want a rainbow slime but you have no reds? Come on down to Mutagen incorporated for a mutation and stabilization potion all in one package!"
 	cost = 3200
-	access = ACCESS_TOXINS
+	access = ACCESS_TOX_STORAGE
 	contains = list(/obj/item/slimepotion/slime/stabilizer,
     				/obj/item/slimepotion/slime/mutator)
 	crate_name = "Xenobiology Mutagen crate"
@@ -14,7 +14,7 @@
 	name = "Xenobiology Slime Steroid crate"
 	desc = "Everything a new xenobiologist needs to be efficent in their work! Comes with 2 bottles of slime steroids"
 	cost = 4500
-	access = ACCESS_TOXINS
+	access = ACCESS_TOX_STORAGE
 	contains = list(/obj/item/slimepotion/slime/steroid,
     				/obj/item/slimepotion/slime/steroid)
 	crate_name = "Xenobiology Slime Steroid crate"

--- a/austation/code/modules/cargo/packs.dm
+++ b/austation/code/modules/cargo/packs.dm
@@ -1,17 +1,7 @@
 //Science
 
-/datum/supply_pack/science/slimesteroid
-	name = "Xenobiology Slime Steroid crate"
-	desc = "Everything a new xenobiologist needs to be efficent in their work! Comes with 2 bottles of slime steroids "
-	cost = 4500
-	access = ACCESS_TOXINS
-	contains = list(/obj/item/slimepotion/slime/steroid,
-    				/obj/item/slimepotion/slime/steroid)
-	crate_name = "Xenobiology Slime Steroid crate"
-	crate_type = /obj/structure/closet/crate/secure/science
-
-/datum/supply_pack/science/slimeMutagens
-	name = "Xenobiology Mutagens crate"
+/datum/supply_pack/science/slimemutagen
+	name = "Xenobiology Mutagen crate"
 	desc = "Hate that one slime who won't stop mutating? Desperately want a rainbow slime but you have no reds? Come on down to Mutagen incorporated for a mutation and stabilization potion all in one package!"
 	cost = 3200
 	access = ACCESS_TOXINS
@@ -20,3 +10,12 @@
 	crate_name = "Xenobiology Mutagen crate"
 	crate_type = /obj/structure/closet/crate/secure/science
 
+/datum/supply_pack/science/slimesteroid
+	name = "Xenobiology Slime Steroid crate"
+	desc = "Everything a new xenobiologist needs to be efficent in their work! Comes with 2 bottles of slime steroids"
+	cost = 4500
+	access = ACCESS_TOXINS
+	contains = list(/obj/item/slimepotion/slime/steroid,
+    				/obj/item/slimepotion/slime/steroid)
+	crate_name = "Xenobiology Slime Steroid crate"
+	crate_type = /obj/structure/closet/crate/secure/science

--- a/austation/code/modules/cargo/packs.dm
+++ b/austation/code/modules/cargo/packs.dm
@@ -9,3 +9,14 @@
     				/obj/item/slimepotion/slime/steroid)
 	crate_name = "Xenobiology Slime Steroid crate"
 	crate_type = /obj/structure/closet/crate/secure/science
+
+/datum/supply_pack/science/slimeMutagens
+	name = "Xenobiology Mutagens crate"
+	desc = "Hate that one slime who won't stop mutating? Desperately want a rainbow slime but you have no reds? Come on down to Mutagen incorporated for a mutation and stabilization potion all in one package!"
+	cost = 3200
+	access = ACCESS_TOXINS
+	contains = list(/obj/item/slimepotion/slime/stabilizer,
+    				/obj/item/slimepotion/slime/mutator)
+	crate_name = "Xenobiology Mutagen crate"
+	crate_type = /obj/structure/closet/crate/secure/science
+

--- a/austation/code/modules/cargo/packs.dm
+++ b/austation/code/modules/cargo/packs.dm
@@ -1,19 +1,9 @@
 //Science
 
-/datum/supply_pack/science/slimemutagen
-	name = "Xenobiology Mutagen crate"
-	desc = "Hate that one slime who won't stop mutating? Desperately want a rainbow slime but you have no reds? Come on down to Mutagen incorporated for a mutation and stabilization potion all in one package!"
-	cost = 3200
-	access = ACCESS_TOX_STORAGE
-	contains = list(/obj/item/slimepotion/slime/stabilizer,
-    				/obj/item/slimepotion/slime/mutator)
-	crate_name = "Xenobiology Mutagen crate"
-	crate_type = /obj/structure/closet/crate/secure/science
-
 /datum/supply_pack/science/slimesteroid
 	name = "Xenobiology Slime Steroid crate"
 	desc = "Everything a new xenobiologist needs to be efficent in their work! Comes with 2 bottles of slime steroids"
-	cost = 4500
+	cost = 5500
 	access = ACCESS_TOX_STORAGE
 	contains = list(/obj/item/slimepotion/slime/steroid,
     				/obj/item/slimepotion/slime/steroid)

--- a/austation/code/modules/cargo/packs.dm
+++ b/austation/code/modules/cargo/packs.dm
@@ -1,0 +1,11 @@
+//Science
+
+/datum/supply_pack/science/slimesteroid
+	name = "Xenobiology Slime Steroid crate"
+	desc = "Everything a new xenobiologist needs to be efficent in their work! Comes with 2 bottles of slime steroids "
+	cost = 4500
+	access = ACCESS_TOXINS
+	contains = list(/obj/item/slimepotion/slime/steroid,
+                  /obj/item/slimepotion/slime/steroid)
+	crate_name = "Xenobiology Slime Steroid crate"
+	crate_type = /obj/structure/closet/crate/secure/science

--- a/austation/includes.dm
+++ b/austation/includes.dm
@@ -112,3 +112,4 @@
 #include "code\modules\atmospherics\machinery\components\unary_devices\thermomachine.dm"
 #include "code\modules\cargo\exports\food_and_drink\processed.dm"
 #include "code\modules\cargo\exports\organs.dm"
+#include "code\modules\cargo\packs.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a crate
Xenobiology Slime Steroid crates for 2 slime steroids

## Why It's Good For The Game

Encourages inter-department cooperation without locking a necessary feature behind a paywall
Xenobiologists will be a lot better off with giving steroids to 3 slimes instead of the 20 slimes they will have by the time they get purples.

## Changelog
:cl:
add: adds Xenobiology steroids crate to cargo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
