### PR TITLE
merge stand meteors from yog

### DIFF
--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -4,13 +4,13 @@ GLOBAL_VAR_INIT(meteor_wave_delay, 625) //minimum wait between waves in tenths o
 
 //Meteors probability of spawning during a given wave
 GLOBAL_LIST_INIT(meteors_normal, list(/obj/effect/meteor/dust=3, /obj/effect/meteor/medium=8, /obj/effect/meteor/big=3, \
-						  /obj/effect/meteor/flaming=1, /obj/effect/meteor/irradiated=3)) //for normal meteor event
+						  /obj/effect/meteor/flaming=1, /obj/effect/meteor/irradiated=3, /obj/effect/meteor/guardian=0.01)) //for normal meteor event
 
 GLOBAL_LIST_INIT(meteors_threatening, list(/obj/effect/meteor/medium=4, /obj/effect/meteor/big=8, \
-						  /obj/effect/meteor/flaming=3, /obj/effect/meteor/irradiated=3)) //for threatening meteor event
+						  /obj/effect/meteor/flaming=3, /obj/effect/meteor/irradiated=3, /obj/effect/meteor/guardian=0.5)) //for threatening meteor event
 
 GLOBAL_LIST_INIT(meteors_catastrophic, list(/obj/effect/meteor/medium=5, /obj/effect/meteor/big=75, \
-						  /obj/effect/meteor/flaming=10, /obj/effect/meteor/irradiated=10, /obj/effect/meteor/tunguska = 1)) //for catastrophic meteor event
+						  /obj/effect/meteor/flaming=10, /obj/effect/meteor/irradiated=10, /obj/effect/meteor/tunguska = 1, /obj/effect/meteor/guardian=1)) //for catastrophic meteor event
 
 GLOBAL_LIST_INIT(meteorsB, list(/obj/effect/meteor/meaty=5, /obj/effect/meteor/meaty/xeno=1)) //for meaty ore event
 
@@ -344,6 +344,16 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 	..()
 	if(prob(20))
 		explosion(src.loc,2,4,6,8)
+		
+/obj/effect/meteor/guardian
+	name = "glowing meteor"
+	icon_state = "glowing"
+	hits = 3
+	heavy = 1
+	meteorsound = 'sound/effects/bamf.ogg'
+	meteordrop = list(/obj/item/stand_arrow)
+	dropamt = 1
+	threat = 100
 
 //////////////////////////
 //Spookoween meteors

--- a/code/modules/guardian/standarrow.dm
+++ b/code/modules/guardian/standarrow.dm
@@ -9,7 +9,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	sharpness = IS_SHARP
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
-	var/kill_chance = 50 // people will still chuck these at the nearest security officer anyways, so who cares
+	var/kill_chance = 30 // This is ready to be changed, only a WIP varible
 	var/in_use = FALSE
 	var/uses = 3
 	var/users = list()


### PR DESCRIPTION
complete the yog-station stand arrow merge

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

it now makes the stand arrow obtainable outside of admin/sandbox spawner panels

## Why It's Good For The Game

Amazing items designed to be obtainable but being made impossible to get makes me angry

## Changelog
:cl:
add: stand meteors, they function like regular meteors but drop stand arrows when they collide
tweak: changes dust chance from stand arrow use from 50 to 30, encouraging risk = reward when obtaining them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
