### PR TITLE
Potato Battery Salt Nerf Removal

### DIFF
--- a/austation/code/modules/hydroponics/plant_genes.dm
+++ b/austation/code/modules/hydroponics/plant_genes.dm
@@ -1,0 +1,23 @@
+/datum/plant_gene/trait/battery/on_attackby(obj/item/reagent_containers/food/snacks/grown/G, obj/item/I, mob/user)
+	if(istype(I, /obj/item/stack/cable_coil))
+		var/obj/item/stack/cable_coil/C = I
+		if(C.use(5))
+			to_chat(user, "<span class='notice'>You add some cable to [G] and slide it inside the battery encasing.</span>")
+			var/obj/item/stock_parts/cell/potato/pocell = new /obj/item/stock_parts/cell/potato(user.loc)
+			pocell.icon_state = G.icon_state
+			pocell.maxcharge = G.seed.potency * 20
+
+			// The secret of potato supercells!
+			var/datum/plant_gene/trait/cell_charge/CG = G.seed.get_gene(/datum/plant_gene/trait/cell_charge)
+			if(CG) // 10x charge for deafult cell charge gene - 20 000 with 100 potency.
+				pocell.maxcharge *= CG.rate*500
+			pocell.charge = pocell.maxcharge
+			pocell.name = "[G.name] battery"
+			pocell.desc = "A rechargeable plant-based power cell. This one has a rating of [DisplayEnergy(pocell.maxcharge)], and you should not swallow it."
+
+			if(G.reagents.has_reagent(/datum/reagent/toxin/plasma, 2))
+				pocell.rigged = TRUE
+
+			qdel(G)
+		else
+			to_chat(user, "<span class='warning'>You need five lengths of cable to make a [G] battery!</span>")

--- a/austation/includes.dm
+++ b/austation/includes.dm
@@ -49,6 +49,7 @@
 #include "code\modules\clothing\under\jobs\civilian\civilian.dm"
 #include "code\modules\events\bruh_moment.dm"
 #include "code\modules\hydroponics\grown.dm"
+#include "code\modules\hydroponics\plant_genes.dm"
 #include "code\modules\food_and_drinks\drinks\drinks.dm"
 #include "code\modules\food_and_drinks\food\snacks_bread.dm"
 #include "code\modules\jobs\job_types\assistant.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes salty tg nerfs
makes potato battery half as glorious 

Potato battery gone from bluespace battery to 5 of them glued together
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Removing TG Salt nerfs makes the game more phun
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: cell charge changed from 100 to 500
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
