### PR TITLE
Desynchronizers are now stuck to your hand while you're using it

### DIFF
--- a/austation/code/game/objects/items/devices/desynchronizer.dm
+++ b/austation/code/game/objects/items/devices/desynchronizer.dm
@@ -1,0 +1,7 @@
+/obj/item/desynchronizer/desync(mob/living/user)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, ABSTRACT_ITEM_TRAIT)
+
+/obj/item/desynchronizer/resync()
+	. = ..()
+	REMOVE_TRAIT(src, TRAIT_NODROP, ABSTRACT_ITEM_TRAIT)

--- a/austation/includes.dm
+++ b/austation/includes.dm
@@ -31,6 +31,7 @@
 #include "code\game\objects\items\sharpener.dm"
 #include "code\game\objects\items\twohanded.dm"
 #include "code\game\objects\items\weaponry.dm"
+#include "code\game\objects\items\devices\desynchronizer.dm"
 #include "code\game\objects\structures\humanfurniture.dm"
 #include "code\game\objects\structures\mirror.dm"
 #include "code\game\turfs\open\lava.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

makes desyncs undroppable when you're desynced

## Why It's Good For The Game

fixes desyncs dropping and disappearing on shuttlestun

## Changelog
:cl:
fix: desyncs no longer disappear on shuttle stun
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
