### PR TITLE
Slime Reproduction Potions Buff

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -195,10 +195,18 @@
 				if(i != 1)
 					step_away(M,src)
 				M.Friends = Friends.Copy()
+			//austation begins - steroid potions & neuter potions effect children
+				M.cores = cores
+				M.neutered = neutered
+
+				if(!neutered)
+					M.mutation_chance = CLAMP(mutation_chance+(rand(5,-5)),0,100)
+				else
+					M.mutation_chance = 0
+			//austation ends
 				babies += M
-				M.mutation_chance = CLAMP(mutation_chance+(rand(5,-5)),0,100)
 				SSblackbox.record_feedback("tally", "slime_babies_born", 1, M.colour)
-				
+
 				if(original_nanites)
 					M.AddComponent(/datum/component/nanites, original_nanites.nanite_volume*0.25)
 					SEND_SIGNAL(M, COMSIG_NANITE_SYNC, original_nanites, TRUE, TRUE) //The trues are to copy activation as well

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -66,6 +66,10 @@
 	var/mutator_used = FALSE //So you can't shove a dozen mutators into a single slime
 	var/force_stasis = FALSE
 
+	//austation start - neuter potions permanently neuter slimes
+	var/neutered = FALSE
+	//austation end
+
 	do_footstep = TRUE
 
 	var/static/regex/slime_name_regex = new("\\w+ (baby|adult) slime \\(\\d+\\)")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes steroid potion and charged stabilizer pass on the effect to children.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: steroid potion and charged stabilizer pass on the effect to children
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
