### PR TITLE
mutant bread now inherits bread force (and reagent fix) 

### DIFF
--- a/austation/code/modules/food_and_drinks/food/snacks_bread.dm
+++ b/austation/code/modules/food_and_drinks/food/snacks_bread.dm
@@ -255,3 +255,12 @@
 		L.dust(force = TRUE)
 		return
 	qdel(hit_atom)
+
+// damage inheritance for mutant bread
+/obj/item/reagent_containers/food/snacks/store/bread/recycled/teleport_act()
+	mutated++
+	reagents.add_reagent(/datum/reagent/toxin/mutagen = 1)
+	if(mutated == 5)
+		new var/mob/living/simple_animal/hostile/breadloaf/brad(src.loc)
+		brad.melee_damage = force
+		qdel(src)

--- a/austation/code/modules/food_and_drinks/food/snacks_bread.dm
+++ b/austation/code/modules/food_and_drinks/food/snacks_bread.dm
@@ -261,6 +261,6 @@
 	mutated++
 	reagents.add_reagent(/datum/reagent/toxin/mutagen = 1)
 	if(mutated == 5)
-		new var/mob/living/simple_animal/hostile/breadloaf/brad(src.loc)
+		var/mob/living/simple_animal/hostile/breadloaf/brad = new(src.loc)
 		brad.melee_damage = force
 		qdel(src)

--- a/austation/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/austation/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -98,6 +98,7 @@
 	taste_description = "quarks"
 	color = "#99ff87"
 	metabolization_rate = 4
+	can_synth = FALSE
 
 /datum/reagent/strange_matter/on_mob_life(mob/living/carbon/M)
 	M.adjustBruteLoss(2)
@@ -124,6 +125,7 @@
 	taste_description = "your mouth vaporizing"
 	color = "#858585"
 	metabolization_rate = 2
+	can_synth = FALSE
 
 /datum/reagent/antimatter/on_mob_add(mob/living/L)
 	to_chat(L, "<span class='userdanger'>You feel the antimatter vaporizing your body!</span>")


### PR DESCRIPTION

## About The Pull Request

mutant bread now has the same force value as the **recycled** bread it's made from, yes this means you can make basically harmless bread if using t1 bread. 
PR also tweaks bread reagents to prevent botany getting antimatter 10 minutes into the round

## Why It's Good For The Game

above

## Changelog
:cl:
tweak: mutant bread now inherits recycled bread stats
tweak: bread reagents can now only be obtained through bread 
/:cl:

