### PR TITLE
Adds the Handy sprite to engiborg radial

### DIFF
--- a/austation/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/austation/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -58,6 +58,7 @@
 		"Marina" = image(icon = 'austation/icons/mob/robot.dmi', icon_state = "marinaeng"),
 		"Can" = image(icon = 'austation/icons/mob/robot.dmi', icon_state = "caneng"),
 		"Spider" = image(icon = 'austation/icons/mob/robot.dmi', icon_state = "spidereng"),
+		"Handy" = image(icon = 'austation/icons/mob/robot.dmi', icon_state = "handyeng"),
 		"Skirt" = image(icon = 'austation/icons/mob/robot.dmi', icon_state = "banangarang-Engineering"))
 	
 	var/engi_borg_icon = show_radial_menu(R, R , robotstyles_eng, custom_check = CALLBACK(src, .proc/check_menu, R), radius = 42, require_near = TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Whoops, missed one option
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
On one hand, haha suck it Hal. No more handy borg for you.
On the other, whoops honest mistake
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Handyeng is once again selectable borg icon
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
