### PR TITLE
Adds a sentient spider infestation event

### DIFF
--- a/austation/code/modules/events/sentient_spider_infestation.dm
+++ b/austation/code/modules/events/sentient_spider_infestation.dm
@@ -1,0 +1,35 @@
+/datum/round_event_control/sentient_spider_infestation
+	name = "Sentient Spider Infestation"
+	typepath = /datum/round_event/sentient_spider_infestation
+	weight = 5
+	max_occurrences = 1
+	min_players = 15
+
+/datum/round_event/sentient_spider_infestation
+	announceWhen	= 400
+	var/spawncount = 1
+
+/datum/round_event/sentient_spider_infestation/setup()
+	announceWhen = rand(announceWhen, announceWhen + 50)
+	spawncount = rand(1, 2)
+
+/datum/round_event/sentient_spider_infestation/announce(fake)
+	priority_announce("Unidentified lifesigns detected coming aboard [station_name()]. Secure any exterior access, including ducting and ventilation.", "Lifesign Alert", 'sound/ai/aliens.ogg')
+
+/datum/round_event/sentient_spider_infestation/start()
+	var/list/vents = list()
+	for(var/obj/machinery/atmospherics/components/unary/vent_pump/temp_vent in GLOB.machines)
+		if(QDELETED(temp_vent))
+			continue
+		if(is_station_level(temp_vent.loc.z) && !temp_vent.welded)
+			var/datum/pipeline/temp_vent_parent = temp_vent.parents[1]
+			if(temp_vent_parent.other_atmosmch.len > 20)
+				vents += temp_vent
+
+	while((spawncount >= 1) && vents.len)
+		var/obj/vent = pick(vents)
+		var/obj/structure/spider/spiderling/nurse/S = new(vent.loc)
+		S.player_spiders = 1
+		announce_to_ghosts(S)
+		vents -= vent
+		spawncount--

--- a/austation/includes.dm
+++ b/austation/includes.dm
@@ -53,6 +53,7 @@
 #include "code\modules\clothing\under\jobs\security.dm"
 #include "code\modules\clothing\under\jobs\civilian\civilian.dm"
 #include "code\modules\events\bruh_moment.dm"
+#include "code\modules\events\sentient_spider_infestation.dm"
 #include "code\modules\hydroponics\grown.dm"
 #include "code\modules\hydroponics\plant_genes.dm"
 #include "code\modules\food_and_drinks\drinks\drinks.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title

## Why It's Good For The Game

You can't play as a spider unless someone at xeno spawns one and intelligence potion it.

## Changelog
:cl:
add: Added a sentient spider infestation random event
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
