### PR TITLE
More australium-able items

### DIFF
--- a/austation/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/austation/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -4,6 +4,7 @@
 	description = "A mysterious metal element that can adapt and transform itself into different states and forms, can make subjects appear down-under."
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	taste_description = "australia"
+	var/static/list/whitelist = typesof(/obj/item/gun) + typesof(/obj/item/melee) + typesof(/obj/item/kitchen) + typesof(/obj/item/crowbar) + typesof(/obj/item/screwdriver) + typesof(/obj/item/wrench) + typesof(/obj/item/wirecutters) + typesof(/obj/item/weldingtool) + typesof(/obj/item/retractor) + typesof(/obj/item/retractor) + typesof(/obj/item/hemostat) + typesof(/obj/item/cautery) + typesof(/obj/item/surgicaldrill) + typesof(/obj/item/scalpel) + typesof(/obj/item/circular_saw) + typesof(/obj/item/nullrod)
 
 /datum/reagent/australium/on_mob_life(mob/living/carbon/M)
 	if(prob(10))
@@ -23,7 +24,7 @@
 	var/obj/item/M = O
 	if(HAS_TRAIT(M, TRAIT_AUSTRALIUM))
 		return ..()
-	else if(istype(O, /obj/item/gun) || istype(O, /obj/item/melee))
+	else if(M.type in whitelist)
 		M.add_atom_colour(rgb(242,190,17), FIXED_COLOUR_PRIORITY)
 		M.name = "australium [M.name]"
 		M.desc = "[M.desc] It's plated in Australium!"

--- a/austation/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/austation/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -4,7 +4,7 @@
 	description = "A mysterious metal element that can adapt and transform itself into different states and forms, can make subjects appear down-under."
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	taste_description = "australia"
-	var/static/list/whitelist = typesof(/obj/item/gun) + typesof(/obj/item/melee) + typesof(/obj/item/kitchen) + typesof(/obj/item/crowbar) + typesof(/obj/item/screwdriver) + typesof(/obj/item/wrench) + typesof(/obj/item/wirecutters) + typesof(/obj/item/weldingtool) + typesof(/obj/item/retractor) + typesof(/obj/item/retractor) + typesof(/obj/item/hemostat) + typesof(/obj/item/cautery) + typesof(/obj/item/surgicaldrill) + typesof(/obj/item/scalpel) + typesof(/obj/item/circular_saw) + typesof(/obj/item/nullrod)
+	var/static/list/whitelist = typesof(/obj/item/gun) + typesof(/obj/item/melee) + typesof(/obj/item/kitchen) + typesof(/obj/item/crowbar) + typesof(/obj/item/screwdriver) + typesof(/obj/item/wrench) + typesof(/obj/item/wirecutters) + typesof(/obj/item/weldingtool) + typesof(/obj/item/retractor) + typesof(/obj/item/retractor) + typesof(/obj/item/hemostat) + typesof(/obj/item/cautery) + typesof(/obj/item/surgicaldrill) + typesof(/obj/item/scalpel) + typesof(/obj/item/circular_saw) + typesof(/obj/item/nullrod) + typesof(/obj/item/storage/toolbox)
 
 /datum/reagent/australium/on_mob_life(mob/living/carbon/M)
 	if(prob(10))

--- a/austation/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/austation/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -4,7 +4,7 @@
 	description = "A mysterious metal element that can adapt and transform itself into different states and forms, can make subjects appear down-under."
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	taste_description = "australia"
-	var/static/list/whitelist = typesof(/obj/item/gun) + typesof(/obj/item/melee) + typesof(/obj/item/kitchen) + typesof(/obj/item/crowbar) + typesof(/obj/item/screwdriver) + typesof(/obj/item/wrench) + typesof(/obj/item/wirecutters) + typesof(/obj/item/weldingtool) + typesof(/obj/item/retractor) + typesof(/obj/item/retractor) + typesof(/obj/item/hemostat) + typesof(/obj/item/cautery) + typesof(/obj/item/surgicaldrill) + typesof(/obj/item/scalpel) + typesof(/obj/item/circular_saw) + typesof(/obj/item/nullrod) + typesof(/obj/item/storage/toolbox)
+	var/static/list/whitelist = typesof(/obj/item/gun) + typesof(/obj/item/melee) + typesof(/obj/item/kitchen) + typesof(/obj/item/crowbar) + typesof(/obj/item/screwdriver) + typesof(/obj/item/wrench) + typesof(/obj/item/wirecutters) + typesof(/obj/item/weldingtool) + typesof(/obj/item/retractor) + typesof(/obj/item/hemostat) + typesof(/obj/item/cautery) + typesof(/obj/item/surgicaldrill) + typesof(/obj/item/scalpel) + typesof(/obj/item/circular_saw) + typesof(/obj/item/nullrod) + typesof(/obj/item/storage/toolbox)
 
 /datum/reagent/australium/on_mob_life(mob/living/carbon/M)
 	if(prob(10))

--- a/beestation.dme
+++ b/beestation.dme
@@ -18,6 +18,7 @@
 
 // BEGIN_INCLUDE
 #include "_maps\_basemap.dm"
+#include "austation\define_includes.dm"
 #include "code\_compile_options.dm"
 #include "code\world.dm"
 #include "code\__DEFINES\_globals.dm"
@@ -2025,9 +2026,9 @@
 #include "code\modules\language\mushroom.dm"
 #include "code\modules\language\narsian.dm"
 #include "code\modules\language\piratespeak.dm"
-#include "code\modules\language\shadowtongue.dm"
 #include "code\modules\language\ratvarian.dm"
 #include "code\modules\language\rlyehian.dm"
+#include "code\modules\language\shadowtongue.dm"
 #include "code\modules\language\slime.dm"
 #include "code\modules\language\swarmer.dm"
 #include "code\modules\language\sylvan.dm"

--- a/beestation.dme
+++ b/beestation.dme
@@ -18,7 +18,6 @@
 
 // BEGIN_INCLUDE
 #include "_maps\_basemap.dm"
-#include "austation\define_includes.dm"
 #include "code\_compile_options.dm"
 #include "code\world.dm"
 #include "code\__DEFINES\_globals.dm"
@@ -2026,9 +2025,9 @@
 #include "code\modules\language\mushroom.dm"
 #include "code\modules\language\narsian.dm"
 #include "code\modules\language\piratespeak.dm"
+#include "code\modules\language\shadowtongue.dm"
 #include "code\modules\language\ratvarian.dm"
 #include "code\modules\language\rlyehian.dm"
-#include "code\modules\language\shadowtongue.dm"
 #include "code\modules\language\slime.dm"
 #include "code\modules\language\swarmer.dm"
 #include "code\modules\language\sylvan.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Surgery tools, kitchen tools, nullrods and just tools in general are now australium-able

## Why It's Good For The Game

Why not

## Changelog
:cl:
add: More australium-able items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
