### PR TITLE
Changes the default view screen to 19x15 instead of 15x15

### DIFF
--- a/code/datums/view.dm
+++ b/code/datums/view.dm
@@ -119,4 +119,4 @@
 /proc/getScreenSize(widescreen) //IMPORTANT: If widescreen toggle preference gets ported, several uses of this proc need to be changed from FALSE to the player pref
 	if(widescreen)
 		return CONFIG_GET(string/default_view)
-	return "15x15" //IMPORTANT: If widescreen toggle preference gets ported, this needs to be set to the square view config
+	return "19x15" //IMPORTANT: If widescreen toggle preference gets ported, this needs to be set to the square view config

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -110,7 +110,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	///What size should pixels be displayed as? 0 is strech to fit
 	var/pixel_size = 0
 	///What scaling method should we use?
-	var/scaling_method = "normal"
+	var/scaling_method = "SCALING_METHOD_NORMAL"
 	var/uplink_spawn_loc = UPLINK_PDA
 
 	var/list/exp = list()

--- a/config/config.txt
+++ b/config/config.txt
@@ -484,7 +484,7 @@ ROUNDS_UNTIL_HARD_RESTART 3
 ##	By default, this is 15x15, which gets simplified to 7 by BYOND, as it is a 1:1 screen ratio.
 ##	For reference, Goonstation uses a resolution of 21x15 for it's widescreen mode.
 ##	Do note that changing this value will affect the title screen. The title screen will have to be updated manually if this is changed.
-DEFAULT_VIEW 15x15
+DEFAULT_VIEW 19x15
 
 ## Name your perpetual currency here
 ## This is used within the metashop and earned by playing the game.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

We can now actually see more than the cramped 1:1 square view we initially had, while also catching up to every other server that has updated to this. Still lagging behind goon's 21x15 though.

## Why It's Good For The Game

This isn't 2009 anymore, we should be able to see more of the game.


## Changelog
:cl:
tweak: tweaked the view pref
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
