### PR TITLE
Fixes loafer deleting people on it being destroyed

### DIFF
--- a/austation/code/modules/recycling/disposal/loafer.dm
+++ b/austation/code/modules/recycling/disposal/loafer.dm
@@ -21,6 +21,21 @@
 	else
 		stored = new /obj/structure/disposalconstruct/au(src, null , SOUTH , FALSE , src)
 
+/obj/structure/disposalpipe/loafer/Destroy()
+	var/obj/structure/disposalholder/H = locate() in src
+	if(H)
+		for(var/atom/movable/AM in H.contents)
+			if(istype(AM, /obj/item/reagent_containers/food/snacks/store/bread/recycled))
+				var/obj/item/reagent_containers/food/snacks/store/bread/recycled/looef = AM
+				if(looef.bread_density < 10)
+					qdel(AM)
+			if(isliving(AM))
+				var/mob/living/L = AM
+				L.adjustBruteLoss(40) //ouchie
+		expel(H, get_turf(src), 0)
+	QDEL_NULL(stored)
+	return ..()
+
 obj/structure/disposalpipe/loafer/emag_act(mob/user)
 	if(obj_flags & EMAGGED)
 		return


### PR DESCRIPTION

## About The Pull Request

yes

## Why It's Good For The Game

It now deals 40 damage instead of deleting people on being destroyed
Resolves #2239 

## Changelog
:cl:
fix: fixed loafer deleting people on destroy
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
