### PR TITLE
Removes borg combat spinning

### DIFF
--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -307,7 +307,7 @@
 	M.visible_message("<span class='warning'>[M] is thrown clear of [AM]!</span>", \
 					"<span class='warning'>You're thrown clear of [AM]!</span>")
 	M.throw_at(target, 14, 5, AM)
-	M.Paralyze(60)
+	M.Knockdown(40) // austation -- changes borg Paralyze(60) to Knockdown(40)
 
 /datum/component/riding/proc/equip_buckle_inhands(mob/living/carbon/human/user, amount_required = 1, riding_target_override = null)
 	var/atom/movable/AM = parent

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -50,7 +50,7 @@
 	. = ..()
 	if(.)
 		user.spin(20, 1)
-/* austation start -- removes borg combat spin
+
 		if(iscyborg(user) && user.has_buckled_mobs())
 			var/mob/living/silicon/robot/R = user
 			var/datum/component/riding/riding_datum = R.GetComponent(/datum/component/riding)
@@ -59,4 +59,4 @@
 					riding_datum.force_dismount(M)
 			else
 				R.unbuckle_all_mobs()
-*/// austation end
+

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -59,4 +59,3 @@
 					riding_datum.force_dismount(M)
 			else
 				R.unbuckle_all_mobs()
-

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -50,7 +50,7 @@
 	. = ..()
 	if(.)
 		user.spin(20, 1)
-
+/* austation start -- removes borg combat spin
 		if(iscyborg(user) && user.has_buckled_mobs())
 			var/mob/living/silicon/robot/R = user
 			var/datum/component/riding/riding_datum = R.GetComponent(/datum/component/riding)
@@ -59,3 +59,4 @@
 					riding_datum.force_dismount(M)
 			else
 				R.unbuckle_all_mobs()
+*/// austation end

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -102,7 +102,7 @@
 
 	wires = new /datum/wires/robot(src)
 	AddComponent(/datum/component/empprotection, EMP_PROTECT_WIRES)
-	
+
 	RegisterSignal(src, COMSIG_PROCESS_BORGCHARGER_OCCUPANT, .proc/charge)
 
 	robot_modules_background = new()
@@ -1174,7 +1174,9 @@
 		else
 			M.visible_message("<span class='boldwarning'>[M] can't climb onto [src] because [M.p_their()] hands are full!</span>")
 		return
-	. = ..(M, force, check_loc)
+	M.visible_message("<span class='boldwarning'>[M] is being loaded onto [src]!</span>") //austation start -- adds borg buckle delay #2278
+	if(do_after(src, 5, target = M))
+		. = ..(M, force, check_loc) //austation end
 
 /mob/living/silicon/robot/unbuckle_mob(mob/user, force=FALSE)
 	if(iscarbon(user))


### PR DESCRIPTION

## About The Pull Request

Removes the ability for macro using borgs to instantly stun anyone not holding two items

## Why It's Good For The Game

cyborgs are meant to be good at doing one specific task designated by their module. security and emagged/syndi borgs are for combat.

To the people (hal) that will inevitably say "but I need muh spin stun or greytider kill me11!"
Please remember you are using external tools to gain a combat advantage.

## Changelog
:cl:
balance: removes borg spin stuns
/:cl:


