### PR TITLE
Set proper required_players for heresy gamemode

### DIFF
--- a/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
+++ b/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
@@ -6,7 +6,7 @@
 	false_report_weight = 5
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Brig Physician")
 	restricted_jobs = list("AI", "Cyborg")
-	required_players = 0
+	required_players = 20 // austation -- set proper required_players for heresy gamemode
 	required_enemies = 1
 	recommended_enemies = 4
 	reroll_friendly = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adjusts heresy gamemode's required_players to be more... sane. Number obviously is open to change; this PR will be closed when corresponding PR happens on upstream. Or... ask me to open a PR on upstream?

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Heresy _needs_ people to be sacrificed and players want to have a _chance_ against heretics. Sorta requested but I too think we need a proper required_players for heresy gamemode, for we periodically have super-lowpop.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: increased required_players of heresy so it wouldn't happen on rounds with too few initial players
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
