### PR TITLE
Adds Critical Headpats

### DIFF
--- a/austation/code/datums/mood_event/generic_positive_events.dm
+++ b/austation/code/datums/mood_event/generic_positive_events.dm
@@ -7,3 +7,8 @@
 	description = "<span class='nicegreen'>I love headpats!</span>\n"
 	mood_change = 2
 	timeout = 2 MINUTES
+
+/datum/mood_event/criticalheadpat
+	description = "<span class='nicegreen'>It was a critical headpat!</span>\n"
+	mood_change = 3
+	timeout = 2 MINUTES

--- a/austation/code/datums/mood_event/generic_positive_events.dm
+++ b/austation/code/datums/mood_event/generic_positive_events.dm
@@ -11,4 +11,4 @@
 /datum/mood_event/criticalheadpat
 	description = "<span class='nicegreen'>It was a critical headpat!</span>\n"
 	mood_change = 3
-	timeout = 2 MINUTES
+	timeout = 4 MINUTES

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -304,6 +304,10 @@
 					"<span class='notice'>You pat [src] on the head.</span>")
 		if(is_species(src, /datum/species/human/felinid)) //austation begin -- do not question this
 			SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "friendly_pat", /datum/mood_event/betterheadpat)
+			if (is_species(M, /datum/species/human/felinid) && prob(1))
+				M.visible_message("<span class='warning'>It was a critical headpat!")
+				SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "friendly_pat", /datum/mood_event/criticalheadpat)
+				SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "friendly_pat", /datum/mood_event/criticalheadpat)
 		else
 			SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "pat", /datum/mood_event/headpat) //austation end
 	else if((M.zone_selected == BODY_ZONE_L_ARM) || (M.zone_selected == BODY_ZONE_R_ARM))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

_"Geuss_ [sic] _I should be making a PR with actaul_ [sic] _content(?) sooner than later"_ -me, a few hours ago

I did it. The problem is, I am not sure if it'll get merged.

Anyways, this PR adds critical headpat mechanic (and corresponding mood event) which is an additional part of already-existing felinid-exclusive headpat code. It checks whether both participants are felinid, and if they are, gives 1% chance of critial headpat. Critical headpats gives a minor (although stronger than any other headpat mood events) mood event to _both_ participants. Minor problem is that the recipient's critical headpat mood event will be erased when the headpat-er decides to pat further.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I mean, I... acutally... have no idea. But I think... more felinid headpats -> better server?

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added critical headpats
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
