### PR TITLE
Prevents Cut Cable From Being Magically Red

### DIFF
--- a/austation/code/modules/power/cable.dm
+++ b/austation/code/modules/power/cable.dm
@@ -1,0 +1,7 @@
+/obj/structure/cable/Initialize(mapload, param_color)
+	. = ..()
+	if(param_color)
+		if(d1)
+			update_stored(2,cable_color)
+		else
+			update_stored(1,cable_color)

--- a/austation/includes.dm
+++ b/austation/includes.dm
@@ -108,6 +108,7 @@
 #include "code\modules\mob\living\simple_animal\hostile\regalrat.dm"
 #include "code\modules\mob\living\simple_animal\hostile\retaliate\kangaroo.dm"
 #include "code\modules\mob\living\simple_animal\slime\slime.dm"
+#include "code\modules\power\cable.dm"
 #include "code\modules\reagents\chemistry\machinery\chem_dispenser.dm"
 #include "code\modules\reagents\chemistry\reagents\alcohol_reagents.dm"
 #include "code\modules\reagents\chemistry\reagents\drink_reagents.dm"

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -100,9 +100,9 @@ By design, d1 is the smallest direction and d2 is the highest
 	GLOB.cable_list += src //add it to the global cable list
 
 	if(d1)
-		stored = new/obj/item/stack/cable_coil(null,2,cable_color)
+		stored = new/obj/item/stack/cable_coil(null,2,param_color) // austation start -- fix cut cable colors
 	else
-		stored = new/obj/item/stack/cable_coil(null,1,cable_color)
+		stored = new/obj/item/stack/cable_coil(null,1,param_color) // austation end
 
 	var/list/cable_colors = GLOB.cable_colors
 	cable_color = param_color || cable_color || pick(cable_colors)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -99,15 +99,18 @@ By design, d1 is the smallest direction and d2 is the highest
 		hide(T.intact)
 	GLOB.cable_list += src //add it to the global cable list
 
-	if(d1)
-		stored = new/obj/item/stack/cable_coil(null,2,param_color) // austation start -- fix cut cable colors
-	else
-		stored = new/obj/item/stack/cable_coil(null,1,param_color) // austation end
-
+	// austation start -- fix cut cable colors
 	var/list/cable_colors = GLOB.cable_colors
 	cable_color = param_color || cable_color || pick(cable_colors)
 	if(cable_colors[cable_color])
 		cable_color = cable_colors[cable_color]
+
+	if(d1)
+		stored = new/obj/item/stack/cable_coil(null,2,cable_color)
+	else
+		stored = new/obj/item/stack/cable_coil(null,1,cable_color)
+	// austation end
+
 	update_icon()
 
 /obj/structure/cable/Destroy()					// called when a cable is deleted

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -99,23 +99,15 @@ By design, d1 is the smallest direction and d2 is the highest
 		hide(T.intact)
 	GLOB.cable_list += src //add it to the global cable list
 
-	var/list/cable_colors = GLOB.cable_colors 	// austation start -- fix cut cable colors
-	cable_color = param_color || cable_color || pick(cable_colors)
-	if(cable_colors[cable_color])
-		cable_color = cable_colors[cable_color] // austation end
-
 	if(d1)
 		stored = new/obj/item/stack/cable_coil(null,2,cable_color)
 	else
 		stored = new/obj/item/stack/cable_coil(null,1,cable_color)
 
-	// austation start -- fix cut cable colors
-	/* var/list/cable_colors = GLOB.cable_colors
+	var/list/cable_colors = GLOB.cable_colors
 	cable_color = param_color || cable_color || pick(cable_colors)
 	if(cable_colors[cable_color])
-		cable_color = cable_colors[cable_color]*/
-	// austation end
-
+		cable_color = cable_colors[cable_color]
 	update_icon()
 
 /obj/structure/cable/Destroy()					// called when a cable is deleted

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -99,16 +99,21 @@ By design, d1 is the smallest direction and d2 is the highest
 		hide(T.intact)
 	GLOB.cable_list += src //add it to the global cable list
 
-	// austation start -- fix cut cable colors
-	var/list/cable_colors = GLOB.cable_colors
+	var/list/cable_colors = GLOB.cable_colors 	// austation start -- fix cut cable colors
 	cable_color = param_color || cable_color || pick(cable_colors)
 	if(cable_colors[cable_color])
-		cable_color = cable_colors[cable_color]
+		cable_color = cable_colors[cable_color] // austation end
 
 	if(d1)
 		stored = new/obj/item/stack/cable_coil(null,2,cable_color)
 	else
 		stored = new/obj/item/stack/cable_coil(null,1,cable_color)
+
+	// austation start -- fix cut cable colors
+	/* var/list/cable_colors = GLOB.cable_colors
+	cable_color = param_color || cable_color || pick(cable_colors)
+	if(cable_colors[cable_color])
+		cable_color = cable_colors[cable_color]*/
 	// austation end
 
 	update_icon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Whilst red indeed is a beautiful color, we certainly don't want cables to turn red for no reason when cut. This PR prevents it by changing the order where the cables are initialized, so it correctly colors the stored cable piece.

I will upstream this if maintainers request it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Better Immersion.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Cables now always return correctly colored cable pieces when cut
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
