### PR TITLE
Revert "Removes borg combat spinning"

### DIFF
--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -307,7 +307,7 @@
 	M.visible_message("<span class='warning'>[M] is thrown clear of [AM]!</span>", \
 					"<span class='warning'>You're thrown clear of [AM]!</span>")
 	M.throw_at(target, 14, 5, AM)
-	M.Knockdown(40) // austation -- changes borg Paralyze(60) to Knockdown(40)
+	M.Paralyze(60)
 
 /datum/component/riding/proc/equip_buckle_inhands(mob/living/carbon/human/user, amount_required = 1, riding_target_override = null)
 	var/atom/movable/AM = parent

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -105,7 +105,7 @@
 
 	wires = new /datum/wires/robot(src)
 	AddComponent(/datum/component/empprotection, EMP_PROTECT_WIRES)
-	
+
 	RegisterSignal(src, COMSIG_PROCESS_BORGCHARGER_OCCUPANT, .proc/charge)
 
 	robot_modules_background = new()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -105,7 +105,7 @@
 
 	wires = new /datum/wires/robot(src)
 	AddComponent(/datum/component/empprotection, EMP_PROTECT_WIRES)
-
+	
 	RegisterSignal(src, COMSIG_PROCESS_BORGCHARGER_OCCUPANT, .proc/charge)
 
 	robot_modules_background = new()
@@ -1189,9 +1189,7 @@
 		else
 			M.visible_message("<span class='boldwarning'>[M] can't climb onto [src] because [M.p_their()] hands are full!</span>")
 		return
-	M.visible_message("<span class='boldwarning'>[M] is being loaded onto [src]!</span>") //austation start -- adds borg buckle delay #2278
-	if(do_after(src, 5, target = M))
-		. = ..(M, force, check_loc) //austation end
+	. = ..(M, force, check_loc)
 
 /mob/living/silicon/robot/unbuckle_mob(mob/user, force=FALSE)
 	if(iscarbon(user))


### PR DESCRIPTION
## About The Pull Request
Reverts austation/austation#2278
## Why It's Good For The Game

Now that I've tested the nerfed spins out I can confidently say they are cringe.
Now that I'm back from my holiday let me take apart this PR and tell you why it is bad

> cyborgs are meant to be good at doing one specific task designated by their module. security and emagged/syndi borgs are for combat
Cyborgs were, are, and will always be shit at combat
Non lethally in combat:
An Engi borg has
- A flash (Countered by advanced sunglasses/welding helmet/literally spray painted eyewear)
- and spin (Comparable to a human shove)

that's it
sure there are other unique things you could do like drag around beepsky, maybe drag around a thing of n2o, but that means you have time/resources to get them in the first place. in the heat of the moment, with a human greytider with advanced sunglasses (easily gotten) and a flash that, if it gets you, almost GUARANTEES you will die, spinning is your only option. (Which, by the way, put you into range of the flash and if you get a lagspike or are too slow you WILL get flashed)

Humans can:
Shove 
aggressive grab (Tablestun./throw)
any number of non-lethal items they can get their hands on:
- stun stick/stun prod/telescopic baton
- flash
- disabler
- dragnet
- and more
Can ingest chems 
- Stun resistance (rip borg who thought he had 2 more seconds)
- meth speed (borgs can't speed up apart from rare VTEC module)
laserpointers
and more

once again, cyborgs, while stronger than a naked human don't compare to a human that has items, *as it always has been.*

The only cyborgs that can compare to a kitted out human (or hell just a human with a flash) is emagged (Traitor) or security which, on austation, is locked behind research and mats and is thus very rare.

Furthermore just because a module is made to do a specific purpose doesn't mean they can't try and be robust and sitting there, knowing you can do nothing to a greytider/traitor/shitter who is harming a human just cause they have advanced sunglasses is cringe.

> To the people (hal) that will inevitably say "but I need muh spin stun or greytider kill me11!"

First:
![ezgif-3-f9fd1bb35cbe](https://user-images.githubusercontent.com/60122079/95076939-3a77ce00-0745-11eb-9512-df2c690e4072.gif)
Second: 
Cyborgs have hard counters, one of which is produced on mass in a vulnerable area that stuns you enough to kill you with a fire extinguisher and can be refilled with LIGHT BULBS
They can be range countered by a laserpointer that has high tier parts (or hell level 2 is still dangerous)
So yes, I DO need spin stun in order to have just a chance against anyone with these low tier items,

> Please remember you are using external tools to gain a combat advantage.

bruh what?
![Proof](https://user-images.githubusercontent.com/60122079/95079598-6f861f80-0749-11eb-9eb1-ce1380dd26ef.PNG)
i've been using stacked text boxes ever since I got bwoinked for it cause like, I don't want to be banned? I have not been using auto hotkey for ages and all the spin stuns are from me moving my mouse fast and using a semblance of skill.

TLDR: Re-adds spin stuns as they are sorely needed by borgs, reverts the ided PR.

Changelog
🆑
balance: Borg spins stun again
balance: You can buckle/be buckled to a borg instantly again
balance: Borgs can no longer buckle stunned/unconscious bodies 
/🆑

