### PR TITLE
Drone refresh 2

### DIFF
--- a/austation/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/austation/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -1,3 +1,20 @@
+
+/mob/living/simple_animal/drone
+	see_in_dark = 1
+	laws = \
+	"1. You may not involve yourself in the matters of carbons, even if such matters conflict with Law Two or Law Three.\n"+\
+	"2. You may not harm any carbon, regardless of intent or circumstance.\n"+\
+	"3. Your goals are to actively build, maintain, repair, improve, and provide power to the best of your abilities within the facility that housed your activation." //for derelict drones so they don't go to station.
+	var/obj/item/radio/radio = null
+
+/mob/living/simple_animal/drone/Initialize()
+	. = ..()
+	radio = new /obj/item/radio/borg(src) // Grants drones the ability to hear common and engineering radio.
+	radio.keyslot = new /obj/item/encryptionkey/headset_eng
+
+/mob/living/simple_animal/drone/derelict
+	initial_language_holder = /datum/language_holder/drone/derelict
+
 /mob/living/simple_animal/drone/RangedAttack(atom/A, mouseparams)
 	. = ..()
 
@@ -9,3 +26,5 @@
 	var/obj/item/tank/jetpack/J = internal_storage
 	if(istype(J))
 		return J
+
+

--- a/austation/code/modules/mob/living/simple_animal/friendly/drone/say.dm
+++ b/austation/code/modules/mob/living/simple_animal/friendly/drone/say.dm
@@ -1,0 +1,48 @@
+/mob/living/simple_animal/drone/radio(message, message_mode, list/spans, language)
+	. = ..()
+	if(. != 0)
+		return .
+
+	if(message_mode == "robot")
+		if (radio)
+			radio.talk_into(src, message, , spans, language)
+		return REDUCE_RANGE
+
+	return 0
+
+// Drones understand common and can speak machine, such as with IPCs and borgs.
+/datum/language_holder/drone
+	understood_languages = list(/datum/language/drone = list(LANGUAGE_ATOM),
+								/datum/language/machine = list(LANGUAGE_ATOM),
+								/datum/language/common = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/drone = list(LANGUAGE_ATOM),
+							/datum/language/machine = list(LANGUAGE_ATOM))
+	blocked_languages = list()
+
+// Derelict drones don't speak machine, as its too modern for them.
+/datum/language_holder/drone/derelict
+	understood_languages = list(/datum/language/drone = list(LANGUAGE_ATOM),
+								/datum/language/machine = list(LANGUAGE_ATOM),
+								/datum/language/common = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/drone = list(LANGUAGE_ATOM))
+
+// Overwrites but references the upstream handle_message proc for binary. This allows drones to speak on binary, but
+/datum/saymode/binary/handle_message(mob/living/user, message, datum/language/language)
+	if(istype(user, /mob/living/simple_animal/drone/derelict)) // Derelict drones can only use drone chat (as per upstream)
+		. = ..()
+		return .
+	if(isdrone(user) && user.binarycheck()) // All other drones that use binary
+		user.robot_talk(message)
+		return FALSE
+	return ..() // Anything that isn't a drone is handled normally.
+
+/datum/saymode/drone // Handles the drone exclusive chat
+	key = "d"
+	mode = "drone"
+
+/datum/saymode/drone/handle_message(mob/living/user, message, datum/language/language)
+	if(isdrone(user))
+		var/mob/living/simple_animal/drone/D = user
+		D.drone_chat(message)
+		return FALSE
+	return FALSE // If your not a drone, no drone chat for you

--- a/austation/code/modules/mob/living/simple_animal/friendly/drone/say.dm
+++ b/austation/code/modules/mob/living/simple_animal/friendly/drone/say.dm
@@ -15,8 +15,7 @@
 	understood_languages = list(/datum/language/drone = list(LANGUAGE_ATOM),
 								/datum/language/machine = list(LANGUAGE_ATOM),
 								/datum/language/common = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/drone = list(LANGUAGE_ATOM),
-							/datum/language/machine = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/drone = list(LANGUAGE_ATOM))
 	blocked_languages = list()
 
 // Derelict drones don't speak machine, as its too modern for them.

--- a/austation/code/modules/mob/living/simple_animal/friendly/drone/say.dm
+++ b/austation/code/modules/mob/living/simple_animal/friendly/drone/say.dm
@@ -29,8 +29,7 @@
 // Overwrites but references the upstream handle_message proc for binary. This allows drones to speak on binary, but
 /datum/saymode/binary/handle_message(mob/living/user, message, datum/language/language)
 	if(istype(user, /mob/living/simple_animal/drone/derelict)) // Derelict drones can only use drone chat (as per upstream)
-		. = ..()
-		return .
+		return ..()
 	if(isdrone(user) && user.binarycheck()) // All other drones that use binary
 		user.robot_talk(message)
 		return FALSE

--- a/austation/code/modules/mob/living/simple_animal/friendly/drone/say.dm
+++ b/austation/code/modules/mob/living/simple_animal/friendly/drone/say.dm
@@ -21,9 +21,7 @@
 
 // Derelict drones don't speak machine, as its too modern for them.
 /datum/language_holder/drone/derelict
-	understood_languages = list(/datum/language/drone = list(LANGUAGE_ATOM),
-								/datum/language/machine = list(LANGUAGE_ATOM),
-								/datum/language/common = list(LANGUAGE_ATOM))
+	understood_languages = list(/datum/language/drone = list(LANGUAGE_ATOM))
 	spoken_languages = list(/datum/language/drone = list(LANGUAGE_ATOM))
 
 // Overwrites but references the upstream handle_message proc for binary. This allows drones to speak on binary, but

--- a/austation/code/modules/mob/living/simple_animal/friendly/drone/say.dm
+++ b/austation/code/modules/mob/living/simple_animal/friendly/drone/say.dm
@@ -23,23 +23,3 @@
 /datum/language_holder/drone/derelict
 	understood_languages = list(/datum/language/drone = list(LANGUAGE_ATOM))
 	spoken_languages = list(/datum/language/drone = list(LANGUAGE_ATOM))
-
-// Overwrites but references the upstream handle_message proc for binary. This allows drones to speak on binary, but
-/datum/saymode/binary/handle_message(mob/living/user, message, datum/language/language)
-	if(istype(user, /mob/living/simple_animal/drone/derelict)) // Derelict drones can only use drone chat (as per upstream)
-		return ..()
-	if(isdrone(user) && user.binarycheck()) // All other drones that use binary
-		user.robot_talk(message)
-		return FALSE
-	return ..() // Anything that isn't a drone is handled normally.
-
-/datum/saymode/drone // Handles the drone exclusive chat
-	key = "d"
-	mode = "drone"
-
-/datum/saymode/drone/handle_message(mob/living/user, message, datum/language/language)
-	if(isdrone(user))
-		var/mob/living/simple_animal/drone/D = user
-		D.drone_chat(message)
-		return FALSE
-	return FALSE // If your not a drone, no drone chat for you

--- a/austation/code/modules/research/designs/mechfabricator_designs.dm
+++ b/austation/code/modules/research/designs/mechfabricator_designs.dm
@@ -97,3 +97,14 @@
 	materials = list(/datum/material/iron=15000,/datum/material/gold=10000,/datum/material/silver=10000,/datum/material/titanium=10000)
 	construction_time = 600
 	category = list("Gygax")
+
+
+/datum/design/drone_shell
+	name = "Drone Shell"
+	desc = "A shell of a maintenance drone, an expendable robot built to perform station repairs.."
+	id = "drone_shell"
+	build_type = MECHFAB
+	build_path = /obj/item/drone_shell
+	materials = list(/datum/material/iron=2000,/datum/material/gold=200,/datum/material/glass=1500)
+	construction_time = 100
+	category = list("Misc")

--- a/austation/includes.dm
+++ b/austation/includes.dm
@@ -104,6 +104,7 @@
 #include "code\modules\mob\living\simple_animal\friendly\drone\_drone.dm"
 #include "code\modules\mob\living\simple_animal\friendly\drone\drone_movement.dm"
 #include "code\modules\mob\living\simple_animal\friendly\drone\emote.dm"
+#include "code\modules\mob\living\simple_animal\friendly\drone\say.dm"
 #include "code\modules\mob\living\simple_animal\friendly\drone\visuals_icons.dm"
 #include "code\modules\mob\living\simple_animal\friendly\mouse.dm"
 #include "code\modules\mob\living\simple_animal\hostile\generic.dm"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -310,7 +310,7 @@
 	display_name = "Basic Robotics Research"
 	description = "Programmable machines that make our lives lazier."
 	prereq_ids = list("base")
-	design_ids = list("paicard")
+	design_ids = list("paicard", "drone_shell") // Austation -- Makes drone shells printable
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reintroduces drones onto the station. Drones now have access to a built in radio, which can recieve from the common and engineering channels, but cannot transmit. Drones can also speak in binary, and understand common.

Drones also now also have a modified lawset, which lets them interact with silicons. Basically, it makes drones less boring.

This may be unbalanced, but I'd like to see this change tested first. I have more changes to drones underway, to better control drones and prevent them being exploited.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Drones are an underappreciated mob, with a lot of potential. I just think they lack any interactability, which often makes drone gameplay very dull.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Drones get a built-in radio, connected to the common and engineering channels. It cannot transmit however.
add: Drones can be built at mech fabricators, once basic robotics is researched, at the cost of iron, glass and some gold.
tweak: Drones can speak in silicon, and can understand common. Derelict drones cannot speak silicon.
tweak: Drones can speak on binary with the :b prefix. The drone exclusive channel has been moved to the :d prefix. Derelict drones can only use dronechat.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
