### PR TITLE
Rings now tied to body, not client

### DIFF
--- a/austation/code/modules/mob/living/carbon/human/examine.dm
+++ b/austation/code/modules/mob/living/carbon/human/examine.dm
@@ -2,18 +2,15 @@
 	var/t_He = p_they(TRUE)
 	var/t_is = p_are()
 
-
-	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user, .) // circle game
-	if(client) // rings
-		var/datum/preferences/prefs = client.prefs // store datum for faster access
-		if(prefs.ring_type != RING_DISABLED)
-			switch(prefs.ring_type)
+	if(!ringsoff) // rings
+		if(ring_type != RING_DISABLED)
+			switch(ring_type)
 				if(RING_CASUAL)
-					. += "<span class='info'>[t_He] [t_is] wearing a casual ring[prefs.ring_engraved ? " with *" + prefs.ring_engraved + "* etched into it" : ""]~</span>"
+					. += "<span class='info'>[t_He] [t_is] wearing a casual ring[ring_engraved ? " with <i>" + ring_engraved + "</i> etched into it" : ""]~</span>"
 				if(RING_ENGAGEMENT)
-					. += "<span class='info'>[t_He] [t_is] wearing an engagement ring[prefs.ring_engraved ? " with *" + prefs.ring_engraved + "* etched into it" : ""]~</span>"
+					. += "<span class='info'>[t_He] [t_is] wearing an engagement ring[ring_engraved ? " with <i>" + ring_engraved + "</i> etched into it" : ""]~</span>"
 				if(RING_WEDDING)
-					. += "<span class='info'>[t_He] [t_is] wearing a wedding ring[prefs.ring_engraved ? " with *" + prefs.ring_engraved + "* etched into it" : ""]~</span>"
+					. += "<span class='info'>[t_He] [t_is] wearing a wedding ring[ring_engraved ? " with <i>" + ring_engraved + "</i> etched into it" : ""]~</span>"
 				if(RING_AUSTRALIUM)
-					. += "<span class='info'>[t_He] [t_is] wearing a shiny australium ring[prefs.ring_engraved ? " with *" + prefs.ring_engraved + "* etched into it" : ""]~</span>"
+					. += "<span class='info'>[t_He] [t_is] wearing a shiny australium ring[ring_engraved ? " with <i>" + ring_engraved + "</i> etched into it" : ""]~</span>"
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user, .) // circle game

--- a/austation/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/austation/code/modules/mob/living/carbon/human/human_defines.dm
@@ -1,2 +1,5 @@
 /mob/living/carbon/human
 	var/jumpsuit_style = PREF_SUIT		//suit/skirt
+	var/ring_type = RING_DISABLED
+	var/ring_engraved = ""
+	var/ringsoff = FALSE

--- a/austation/code/modules/mob/mob.dm
+++ b/austation/code/modules/mob/mob.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/human/verb/toggle_rings()
-	set name = "Toggle rings"
+	set name = "Toggle Ring"
 	set category = "IC"
 	var/datum/preferences/prefs = client.prefs
 
@@ -15,6 +15,6 @@
 			to_chat(src, "<span class='notice'>You take off your ring.</span>")
 		else
 			ringsoff = FALSE
-			to_chat(src, "<span class='notice'>You put your rings back on.</span>")
+			to_chat(src, "<span class='notice'>You put your ring back on.</span>")
 	else
 		to_chat(src, "<span class='warning'>You don't have any rings.</span>")

--- a/austation/code/modules/mob/mob_defines.dm
+++ b/austation/code/modules/mob/mob_defines.dm
@@ -1,3 +1,2 @@
 /mob
 	var/list/emotes_used
-	var/ringsoff = FALSE

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1974,6 +1974,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	character.backbag = backbag
 
 	character.jumpsuit_style = jumpsuit_style //austation -- skirts
+	character.ring_type = ring_type // austation -- rings
+	character.ring_engraved = ring_engraved // austation -- rings
 
 	var/datum/species/chosen_species
 	chosen_species = pref_species.type

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -96,9 +96,8 @@
 
 	// AuStation Wear Examines (Human)
 	if(istype(src, /mob/living/carbon/human))
-		if(ringsoff == FALSE)
-			var/mob/living/carbon/human/H = src
-			. += H.austation_wear_examine(user)
+		var/mob/living/carbon/human/H = src
+		. += H.austation_wear_examine(user)
 
 	//Status effects
 	. += status_effect_examines()


### PR DESCRIPTION
##  About The Pull Request
Does what it says on the tin. Rings are now bound to your body. Switching body no longer brings your rings with you unless it creates a new body based on your prefs. Cloning doesn't count because it only copies DNA.
Also fixes a bug where disabling rings broke the circle game (thanks, kat for breaking it)
Fixes spans on rings text too.
Tested:tm:

## Why It's Good For The Game
Maybe JoJo will stop whining now?

## Changelog
:cl:
fix: Ring toggle breaking circle game
spellcheck: Ring text spans
tweak: Rings now bound to body not client
/:cl: