### PR TITLE
fixes some bugs with the reactor port

### DIFF
--- a/_maps/map_files/Austation/Austation.dmm
+++ b/_maps/map_files/Austation/Austation.dmm
@@ -45546,13 +45546,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8
-	},
 /obj/machinery/power/apc/auto_name/north,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Moderator to Reactor"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
@@ -54461,13 +54461,19 @@
 /area/maintenance/fore)
 "jza" = (
 /obj/structure/table/reinforced,
-/obj/item/sealant,
-/obj/item/sealant,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/sealant,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
+	},
+/obj/item/sealant{
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/food/snacks/pizzaslice/meat{
+	pixel_x = -1;
+	pixel_y = 12
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
@@ -62641,7 +62647,7 @@
 /area/bridge)
 "mYp" = (
 /obj/machinery/atmospherics/components/unary/portables_connector,
-/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "mYJ" = (
@@ -63553,6 +63559,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "nqb" = (
@@ -71079,7 +71089,7 @@
 /area/hallway/primary/fore)
 "qhs" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	name = "Moderators to Reactor Scrubbers"
+	name = "Moderators to Reactor"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{

--- a/_maps/map_files/Austation/Austation.dmm
+++ b/_maps/map_files/Austation/Austation.dmm
@@ -4910,13 +4910,8 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "auY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3,
+/obj/structure/cable/yellow,
+/obj/machinery/atmospherics/components/trinary/nuclear_reactor/preset,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "ava" = (
@@ -8222,17 +8217,8 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aKR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Atmospherics to Reactor"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
@@ -10271,11 +10257,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "aTs" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 10
 	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/space,
+/area/space/nearstation)
 "aTD" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -13247,12 +13234,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "beI" = (
-/obj/structure/pool/ladder{
-	dir = 2;
-	pixel_y = 17
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
-/turf/open/pool,
-/area/engine/engineering/reactor_core)
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/turf/open/space,
+/area/space/nearstation)
 "beK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -13739,7 +13727,8 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "bgQ" = (
-/turf/open/pool,
+/obj/effect/turf_decal/stripes/white/line,
+/turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "bgY" = (
 /obj/effect/turf_decal/tile/brown,
@@ -19248,24 +19237,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bHv" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 8
-	},
-/obj/machinery/meter{
-	layer = 2.63;
-	pixel_x = -5;
-	pixel_y = -5;
-	target_layer = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/turf/open/space,
+/area/space/nearstation)
 "bHw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -23055,7 +23030,7 @@
 	dir = 8;
 	name = "Port to Filter"
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bUE" = (
@@ -23174,8 +23149,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bVi" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
-/turf/closed/wall/r_wall,
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/purple{
+	dir = 8
+	},
+/turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "bVj" = (
 /obj/structure/cable/yellow{
@@ -23380,7 +23358,7 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Port to Fuel Pipe"
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -23403,8 +23381,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
@@ -23547,7 +23525,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "bXr" = (
@@ -24269,9 +24246,6 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 5
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
@@ -30361,9 +30335,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cxg" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1{
-	dir = 10
-	},
 /obj/item/radio/intercom{
 	pixel_x = 26
 	},
@@ -38356,11 +38327,11 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "dhz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 10
 	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering/reactor_core)
+/turf/open/space/basic,
+/area/space)
 "dhA" = (
 /obj/machinery/washing_machine,
 /obj/structure/sign/poster/official/random{
@@ -38932,7 +38903,8 @@
 /turf/open/floor/plating,
 /area/chapel/main)
 "dkd" = (
-/obj/structure/cable/white{
+/obj/machinery/pool/controller,
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
@@ -38950,11 +38922,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"dkj" = (
-/obj/structure/cable/white,
-/obj/machinery/atmospherics/components/trinary/nuclear_reactor/preset,
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "dkC" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -41070,7 +41037,7 @@
 /area/maintenance/starboard)
 "dUd" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
 /turf/closed/wall/r_wall,
 /area/engine/engineering/reactor_control)
 "dUl" = (
@@ -42605,10 +42572,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering/reactor_control)
 "eFK" = (
@@ -43054,6 +43022,12 @@
 	dir = 5
 	},
 /area/crew_quarters/heads/hor)
+"eOm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/pool,
+/area/engine/engineering/reactor_core)
 "eOs" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -43386,11 +43360,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "eZo" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
+/turf/open/space,
+/area/space/nearstation)
 "eZs" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Quiet Room"
@@ -43663,8 +43638,9 @@
 /turf/closed/wall,
 /area/hallway/secondary/entry)
 "fdn" = (
-/obj/effect/landmark/nuclear_waste_spawner/strong,
-/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "fdr" = (
@@ -44219,13 +44195,14 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "fqf" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/machinery/meter,
+/turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "fqs" = (
 /obj/structure/bed,
@@ -44501,8 +44478,8 @@
 /area/crew_quarters/kitchen/coldroom)
 "fwu" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 5
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -44647,6 +44624,9 @@
 "fzW" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -45520,14 +45500,8 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "fSQ" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/camera/autoname{
-	dir = 9
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Coolent to Reactor"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
@@ -45548,11 +45522,15 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "fTQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos{
-	id_tag = "nuclear_min_out";
-	internal_pressure_bound = 4500
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/turf/open/floor/engine/airless,
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "fTV" = (
 /obj/machinery/door/airlock/external{
@@ -46321,11 +46299,13 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "gkV" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/engine/engineering/reactor_core)
+/obj/machinery/meter,
+/turf/open/space,
+/area/space/nearstation)
 "gld" = (
 /obj/machinery/holopad,
 /obj/structure/cable/yellow{
@@ -47197,16 +47177,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"gGt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/pump/layer3,
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "gGx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -47344,6 +47314,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"gKg" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 10
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "gKr" = (
 /obj/structure/table/wood,
 /obj/machinery/light_switch{
@@ -47811,19 +47791,9 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "gRQ" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/visible,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/turf/closed/wall/r_wall,
+/area/engine/engineering/reactor_control)
 "gSi" = (
 /obj/machinery/light/small,
 /obj/structure/disposalpipe/segment{
@@ -48154,18 +48124,11 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "had" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 10
+/obj/structure/cable/white{
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer3{
-	dir = 10
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/closed/wall/r_wall,
+/area/engine/engineering/reactor_control)
 "hau" = (
 /obj/structure/chair{
 	dir = 8
@@ -48248,6 +48211,10 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"hbx" = (
+/obj/machinery/light,
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "hbU" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon{
@@ -48413,6 +48380,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/carpet/royalblack,
 /area/engine/engineering/reactor_control)
 "heA" = (
@@ -49222,6 +49190,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"hsx" = (
+/obj/structure/grille/broken,
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
 "hsP" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -50244,9 +50216,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "hPI" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -50435,7 +50404,7 @@
 /area/janitor)
 "hVj" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 6
 	},
 /turf/open/space/basic,
@@ -50793,25 +50762,12 @@
 /turf/open/floor/carpet/green,
 /area/chapel/main)
 "iem" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1{
-	dir = 8
+/obj/item/twohanded/required/fuel_rod,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 6;
-	pixel_x = 5
-	},
-/obj/machinery/meter{
-	pixel_x = 5;
-	pixel_y = 5;
-	target_layer = 3
-	},
-/turf/open/floor/engine,
+/turf/open/pool,
 /area/engine/engineering/reactor_core)
-"ieJ" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "ifa" = (
 /obj/structure/closet/emcloset,
 /obj/structure/sign/warning/pods{
@@ -51501,6 +51457,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
+"iqZ" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Cooling Loop to Reactor"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "irb" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -51900,7 +51863,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "iBo" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "iBN" = (
@@ -51989,18 +51952,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/nanite)
-"iDf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable/white{
-	icon_state = "0-2"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "iDq" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -52024,15 +51975,10 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "iEb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/power/smes,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable/white,
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
@@ -52726,25 +52672,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"iQp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/power/smes,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "iQB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54265,12 +54192,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "juz" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 4
+/obj/structure/cable/white{
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering/reactor_control)
 "juG" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -54299,6 +54228,12 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"juM" = (
+/obj/machinery/door/poddoor{
+	id = "au_nuclear_vent"
+	},
+/turf/open/space/basic,
+/area/engine/engineering/reactor_core)
 "juP" = (
 /turf/closed/wall/r_wall,
 /area/engine/engineering/reactor_core)
@@ -54487,12 +54422,13 @@
 	},
 /area/maintenance/fore)
 "jza" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos{
-	dir = 1;
-	id = "nuclear_mix_in"
+/obj/structure/table/reinforced,
+/obj/item/sealant,
+/obj/item/sealant,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/camera/autoname,
-/turf/open/floor/engine/airless,
+/turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "jzp" = (
 /obj/machinery/door/airlock/external{
@@ -54961,9 +54897,10 @@
 	},
 /area/maintenance/aft)
 "jHD" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
+/obj/structure/lattice,
+/obj/structure/grille/broken,
 /turf/closed/wall/r_wall,
-/area/engine/engineering/reactor_control)
+/area/space/nearstation)
 "jHS" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -55004,9 +54941,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "jJK" = (
-/obj/item/twohanded/required/fuel_rod,
-/obj/item/twohanded/required/fuel_rod,
-/obj/item/twohanded/required/fuel_rod,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/pool,
 /area/engine/engineering/reactor_core)
 "jJS" = (
@@ -55307,7 +55244,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
@@ -55327,13 +55264,13 @@
 /turf/open/pool,
 /area/crew_quarters/fitness/recreation)
 "jSa" = (
-/obj/machinery/atmospherics/components/binary/valve/digital/layer1{
-	name = "Moderators to Reactor"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	name = "moderator valve"
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering/reactor_control)
 "jSk" = (
@@ -55440,19 +55377,10 @@
 /turf/open/floor/plasteel/white/side,
 /area/medical/medbay/central)
 "jWf" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Moderators to Reactor Scrubbers"
-	},
-/obj/machinery/atmospherics/components/binary/pump/layer1{
-	dir = 1;
-	name = "Coolants to Reactor scrubbers"
-	},
-/obj/structure/cable/white{
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
@@ -56200,20 +56128,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "klT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/grille/broken,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
 	dir = 4
 	},
-/obj/structure/cable/yellow,
-/obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/engine/engineering/reactor_core";
-	dir = 4;
-	name = "Reactor Core APC";
-	pixel_x = 24
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering/reactor_core)
 "klV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -56571,8 +56490,13 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "kqM" = (
-/obj/machinery/light,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 9
+	},
+/turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "krk" = (
 /obj/machinery/light/small{
@@ -56639,19 +56563,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ksv" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Reactor Tank to Reactor Moderator"
-	},
-/obj/machinery/atmospherics/components/binary/pump/layer1{
-	dir = 1;
-	name = "Connector to Reactor Moderator"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "ksY" = (
@@ -57123,6 +57035,9 @@
 /area/hallway/primary/central)
 "kAT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering/reactor_control)
 "kAW" = (
@@ -57380,11 +57295,11 @@
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "kGL" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1{
-	dir = 6
+/obj/item/twohanded/required/fuel_rod,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/pool,
 /area/engine/engineering/reactor_core)
 "kGW" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -57726,7 +57641,10 @@
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "kOU" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "kOV" = (
@@ -57910,13 +57828,18 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "kSU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	dir = 4;
+	name = "Emergency Coolent Purge"
 	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "kSY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/window,
@@ -58344,18 +58267,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
 "leW" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer3{
-	dir = 5
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "lfd" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -58465,8 +58381,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "lgO" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/visible,
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	dir = 4;
+	name = "Moderator Purge"
+	},
+/turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "lhb" = (
 /obj/item/clothing/head/festive,
@@ -58644,19 +58563,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"lmf" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer3{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "lmh" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -58814,14 +58720,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/plumbing)
 "lrz" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible/layer3,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "lrM" = (
@@ -58924,19 +58825,8 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "ltD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/power/smes,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable/white,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "luo" = (
@@ -59451,15 +59341,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
-"lGj" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/purple/visible/layer1{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblack,
-/area/engine/engineering/reactor_control)
 "lGq" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -60780,7 +60661,7 @@
 /area/maintenance/starboard/secondary)
 "mkg" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -61001,20 +60882,8 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "moS" = (
-/obj/machinery/atmospherics/components/binary/valve/digital/layer3{
-	dir = 4;
-	name = "Reactor Scrubbers to Space"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
+/obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "mpm" = (
@@ -61026,6 +60895,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"mpD" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 6
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "mpZ" = (
 /obj/structure/table/optable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -62447,6 +62326,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"mSK" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "mTr" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -62690,14 +62576,8 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "mYp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/item/sealant,
-/obj/item/sealant,
-/obj/item/sealant,
-/obj/item/sealant,
-/obj/structure/table,
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "mYJ" = (
@@ -63477,8 +63357,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/plumbing)
 "nnu" = (
-/obj/structure/cable/white,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "nnM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -63600,10 +63483,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "npK" = (
-/obj/machinery/air_sensor/atmos{
-	id_tag = "nuclear_mix_sensor"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
 	},
-/turf/open/floor/engine/airless,
+/turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "nqb" = (
 /obj/structure/cable/yellow{
@@ -64467,8 +64350,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "nHr" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/visible,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "nHH" = (
 /obj/machinery/door_timer{
@@ -64613,12 +64498,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
-"nKs" = (
-/obj/machinery/door/poddoor{
-	id = "au_nuclear_vent"
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering/reactor_core)
 "nKG" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/window/reinforced{
@@ -67672,7 +67551,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "oNb" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -67732,14 +67611,11 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "oNJ" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
@@ -67824,7 +67700,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering/reactor_control)
 "oQQ" = (
@@ -68408,21 +68283,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "oZO" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer1,
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction,
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer3,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/spawner/structure/window/plasma/reinforced/shutter,
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "oZP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -70094,7 +69957,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "pHk" = (
@@ -70412,16 +70275,8 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "pPv" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer3{
-	dir = 9
-	},
+/obj/structure/lattice,
+/obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
 "pPD" = (
@@ -71137,13 +70992,13 @@
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "qhs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Moderators to Reactor Scrubbers"
 	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "qhC" = (
@@ -71189,9 +71044,10 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
 "qiQ" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
 	},
+/obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "qiT" = (
@@ -71200,6 +71056,16 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering/reactor_control)
+"qjw" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "qjB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -72032,7 +71898,7 @@
 /area/bridge/showroom/corporate)
 "qCJ" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	name = "Port Mix to Moderator"
+	name = "Port Mix to Reactor Coolent"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -72577,8 +72443,10 @@
 /turf/open/floor/plating,
 /area/medical/sleeper)
 "qMQ" = (
-/obj/effect/spawner/structure/window/plasma/reinforced/shutter,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Reactor to Cooling Loop"
+	},
+/turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "qMR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -72637,7 +72505,7 @@
 /area/science/mixing)
 "qNP" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
 /turf/open/space/basic,
@@ -72658,8 +72526,11 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "qOe" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/engine,
+/obj/item/twohanded/required/fuel_rod,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/pool,
 /area/engine/engineering/reactor_core)
 "qOk" = (
 /obj/machinery/portable_atmospherics/scrubber,
@@ -73070,6 +72941,9 @@
 "qXg" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/engine/engineering/reactor_control)
 "qXm" = (
@@ -73375,6 +73249,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"rcq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "rcL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -74171,8 +74054,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/structure/cable/white{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering/reactor_control)
@@ -74399,14 +74283,8 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "rzC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
-	},
-/obj/machinery/firealarm{
-	pixel_x = -25
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
@@ -75246,15 +75124,9 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
 "rSM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/engine,
+/obj/item/twohanded/required/fuel_rod,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/pool,
 /area/engine/engineering/reactor_core)
 "rTh" = (
 /obj/structure/cable/yellow{
@@ -75309,12 +75181,15 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/structure/table,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	layer = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering/reactor_control)
 "rUK" = (
@@ -75709,7 +75584,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
 "sdz" = (
-/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer1,
+/obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
 "sdO" = (
@@ -76032,6 +75909,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"siB" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 5
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "siF" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -76130,18 +76017,11 @@
 /turf/open/floor/wood,
 /area/library)
 "skg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/binary/pump/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/binary/pump,
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
+/turf/open/floor/plating/airless,
+/area/space)
 "skh" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/white,
@@ -78383,6 +78263,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"tiy" = (
+/obj/effect/spawner/structure/window/plasma/reinforced/shutter,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "tiC" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -78402,9 +78287,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "tiY" = (
-/obj/machinery/atmospherics/components/binary/valve/digital/layer1{
-	name = "Moderators to Reactor tank"
-	},
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/stripes/line{
@@ -79263,10 +79145,11 @@
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "tzk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 5
+/obj/item/twohanded/required/fuel_rod,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/turf/open/floor/engine,
+/turf/open/pool,
 /area/engine/engineering/reactor_core)
 "tzl" = (
 /obj/structure/bed,
@@ -79588,20 +79471,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "tGh" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/meter{
-	layer = 2.63
-	},
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible/layer1,
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "tGM" = (
@@ -80059,10 +79932,13 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "tPl" = (
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
@@ -80646,13 +80522,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "ucJ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/structure/cable/white{
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
@@ -80686,8 +80557,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "udJ" = (
-/obj/machinery/pool/drain,
-/turf/open/pool,
+/obj/effect/turf_decal/stripes/white/corner{
+	dir = 8
+	},
+/turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "uec" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -81133,7 +81006,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "uls" = (
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "ult" = (
 /obj/machinery/navbeacon{
@@ -81413,6 +81292,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/engine/atmos)
 "usy" = (
@@ -81598,8 +81480,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "uwa" = (
-/obj/machinery/light,
-/turf/open/pool,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "uwo" = (
 /obj/structure/cable/yellow{
@@ -81825,8 +81709,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "uCz" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "uCP" = (
 /obj/structure/cable/yellow{
@@ -81840,15 +81727,20 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uCQ" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/door/window/northleft{
-	dir = 8;
-	name = "Inner Pipe Access";
-	req_access_txt = "24"
+/obj/machinery/pool/filter{
+	pixel_y = -18
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "uCR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -82621,10 +82513,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "uSl" = (
-/obj/machinery/light,
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_y = -32
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "uSF" = (
@@ -82755,10 +82647,13 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "uVm" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
-/obj/structure/cable/white{
-	icon_state = "1-2"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 8
+	},
+/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "uVH" = (
@@ -82830,6 +82725,16 @@
 	},
 /turf/closed/wall,
 /area/aisat)
+"uWT" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 9
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "uXd" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -83175,12 +83080,9 @@
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "vcA" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/outlet_injector/layer3{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
+/obj/structure/grille/broken,
+/turf/open/space/basic,
+/area/space)
 "vcF" = (
 /turf/closed/wall/r_wall,
 /area/engine/engineering/reactor_control)
@@ -83194,14 +83096,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "vdc" = (
-/obj/machinery/pool/filter{
-	pixel_y = -18
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/camera/autoname{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 9
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
@@ -83290,7 +83186,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
 "vfp" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
 /turf/open/space/basic,
@@ -84460,7 +84356,7 @@
 /area/medical/surgery)
 "vFY" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 9
 	},
 /turf/open/space/basic,
@@ -85749,14 +85645,9 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "wds" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1,
-/turf/open/floor/engine,
+/obj/machinery/pool/drain,
+/obj/item/twohanded/required/fuel_rod,
+/turf/open/pool,
 /area/engine/engineering/reactor_core)
 "wdy" = (
 /obj/structure/cable/yellow{
@@ -86019,6 +85910,11 @@
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
+"wiP" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/box,
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "wiQ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -86193,9 +86089,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "wnm" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer1{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -86260,15 +86153,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "wpz" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 10
-	},
-/obj/structure/cable/white{
-	icon_state = "1-2"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
@@ -86904,14 +86790,10 @@
 /turf/open/floor/wood,
 /area/library)
 "wGL" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible/layer3{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/purple/visible,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "wHH" = (
@@ -87736,6 +87618,14 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/dorms)
+"wXe" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/box,
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "wXh" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -87911,15 +87801,8 @@
 /area/storage/primary)
 "xdc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/closet/toolcloset,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "xdo" = (
@@ -88002,10 +87885,13 @@
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
 "xed" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/engine,
@@ -88124,9 +88010,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "xgA" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/pool/controller,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/pool,
 /area/engine/engineering/reactor_core)
 "xht" = (
 /obj/structure/cable/yellow{
@@ -88720,9 +88607,14 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "xsO" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/purple{
+	dir = 8
+	},
+/obj/machinery/camera/autoname,
+/turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "xtO" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -90620,17 +90512,8 @@
 /turf/open/floor/carpet/green,
 /area/lawoffice)
 "yeF" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer3{
-	dir = 6
-	},
-/turf/open/space/basic,
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
 /area/space/nearstation)
 "yeO" = (
 /obj/structure/cable/yellow{
@@ -90822,6 +90705,9 @@
 /area/hallway/primary/aft)
 "ykL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "ykS" = (
@@ -133989,9 +133875,9 @@ bIU
 bKB
 bMh
 qCJ
-ieJ
-pHf
 iBo
+pHf
+bIU
 iBo
 bUD
 oNb
@@ -134508,7 +134394,7 @@ bPu
 bPu
 bTl
 bUF
-eZo
+bCv
 bXo
 bMj
 bZI
@@ -135024,7 +134910,7 @@ bNV
 bUH
 bVM
 bXq
-uCQ
+bNV
 bZM
 cbo
 ccU
@@ -135282,7 +135168,7 @@ bIZ
 fzW
 bMl
 bYB
-juz
+bKG
 bKG
 ccV
 qzZ
@@ -135539,7 +135425,7 @@ isy
 usu
 gEK
 nFa
-kSU
+nFa
 wyo
 vKo
 rsZ
@@ -135793,9 +135679,9 @@ aaf
 bFY
 aaf
 bJb
-aaf
-bFY
-aaf
+aTs
+beI
+bHv
 fwu
 pTP
 bWn
@@ -136053,7 +135939,7 @@ bCA
 gJs
 bFZ
 bAR
-fwu
+eZo
 pTP
 gvG
 mqr
@@ -136310,7 +136196,7 @@ bUI
 bVN
 bXr
 bAR
-fwu
+eZo
 pTP
 bWn
 leG
@@ -136567,7 +136453,7 @@ bUJ
 bVO
 bUJ
 bAR
-fwu
+eZo
 pTP
 bWn
 uID
@@ -136824,7 +136710,7 @@ bUJ
 bVP
 bXs
 bAR
-fwu
+eZo
 pTP
 bWn
 mhC
@@ -137081,7 +136967,7 @@ bAR
 bAR
 bAR
 bAR
-fwu
+gkV
 ccZ
 ccY
 lBp
@@ -137338,7 +137224,7 @@ aaf
 aaf
 aaf
 aaf
-fwu
+eZo
 pTP
 bWn
 leG
@@ -137354,7 +137240,7 @@ aaa
 aaf
 aaf
 lMJ
-aaa
+lMJ
 aaa
 aaa
 aaa
@@ -137595,7 +137481,7 @@ aaa
 aaa
 aaa
 aaa
-fwu
+eZo
 pTP
 bWn
 mqr
@@ -137610,10 +137496,10 @@ aaa
 aaa
 aaa
 aaf
-aaa
-lMJ
-aaa
-aaa
+nYJ
+bzi
+yeF
+yeF
 aaa
 aaa
 aaa
@@ -137857,8 +137743,8 @@ pTP
 gvG
 leG
 aaf
-vcA
-aai
+aaa
+klT
 bzj
 aai
 bzj
@@ -137867,10 +137753,10 @@ aaf
 aaf
 aaa
 lMJ
-lMJ
+aaa
 lMJ
 aaa
-aaa
+yeF
 aaa
 aaa
 aaa
@@ -138114,20 +138000,20 @@ qiT
 vbo
 nrr
 vcF
-dhz
+juP
+kOU
+juP
+oZO
+oZO
 juP
 juP
 juP
 juP
-juP
-juP
-juP
-yeF
-leW
 lMJ
-bzi
 aaa
+lMJ
 aaa
+yeF
 aaa
 aaa
 aaa
@@ -138370,21 +138256,21 @@ vcF
 ckK
 bec
 mqk
-vcF
+had
 iEb
-iDf
+xed
 rzC
-vdc
+nVz
+nVz
 bgQ
-bgQ
-bgQ
+wXe
+wiP
 juP
-lmf
-lmf
 lMJ
-bzi
-aaa
-aaa
+mpD
+siB
+lMJ
+yeF
 aaa
 aaa
 aaa
@@ -138627,21 +138513,21 @@ vcF
 ckL
 fKB
 sna
-vcF
-iQp
+juz
+ltD
 xed
 tPl
-kOU
-beI
+nVz
+nVz
 udJ
 uwa
+mSK
 juP
-lmf
-lmf
+lMJ
+qjw
+qjw
 aaa
-bzi
-aaa
-aaa
+yeF
 aaa
 aaa
 aaa
@@ -138884,21 +138770,21 @@ vcF
 tAv
 xAu
 jfH
-vcF
+juz
 ltD
-xed
-tPl
+kSU
+uCQ
 xgA
 jJK
-jJK
-jJK
-juP
-lmf
-lmf
+eOm
+nVz
+nVz
+oZO
 lMJ
-bzi
-aaa
-aaa
+qjw
+qjw
+lMJ
+yeF
 aaa
 aaa
 aaa
@@ -139148,14 +139034,14 @@ jQS
 kGL
 wds
 rSM
-skg
-lgO
+nVz
+nVz
 oZO
 pPv
+qjw
+qjw
 aaa
-bzi
-aaa
-aaa
+yeF
 aaa
 aaa
 aaa
@@ -139399,20 +139285,20 @@ tFn
 oAh
 jef
 qXg
-lrz
 nVz
+leW
 dkd
 iem
 qOe
 tzk
 nVz
-qMQ
-lmf
-sdz
+nVz
+oZO
 lMJ
-bzi
-aaa
-aaa
+qjw
+qjw
+lMJ
+yeF
 aaa
 aaa
 aaa
@@ -139650,8 +139536,8 @@ aaa
 aaa
 aaa
 bzi
-vfp
-vcF
+dhz
+gRQ
 rTZ
 hdT
 eFx
@@ -139661,15 +139547,15 @@ fdn
 jWf
 tGh
 uVm
-dkj
+tGh
 uSl
 qMQ
-lmf
+tiy
 sdz
+uWT
+qjw
 aaa
-bzi
-aaa
-aaa
+yeF
 aaa
 aaa
 aaa
@@ -139907,26 +139793,26 @@ aaa
 aaa
 aaa
 bzi
-vfp
+aaa
 vcF
 jNa
 xrK
 tZa
 sSC
 xdc
-klT
-ucJ
-bHv
-qOe
-qiQ
 nVz
-qMQ
-lmf
+ucJ
+nVz
+leW
+nVz
+rcq
+iqZ
+tiy
 sdz
-lMJ
-bzi
+siB
+qjw
 aaa
-aaa
+yeF
 aaa
 aaa
 aaa
@@ -140164,10 +140050,10 @@ aaa
 aaa
 aaa
 bzi
-aTs
-jHD
+aaa
+vcF
 oQM
-lGj
+wnm
 jSa
 dUd
 xsO
@@ -140175,15 +140061,15 @@ bVi
 qhs
 wGL
 auY
-auY
-gGt
-lgO
+nVz
+uls
+nVz
 oZO
-leW
+lMJ
+qjw
+qjw
 aaa
-bzi
-aaa
-aaa
+yeF
 aaa
 aaa
 aaa
@@ -140430,17 +140316,17 @@ vcF
 fTQ
 lgO
 ksv
-gRQ
+nVz
 nHr
-gkV
+nVz
 uls
-juP
-lmf
-lmf
+nVz
+oZO
 lMJ
-bzi
+qjw
+qjw
 aaa
-aaa
+hsx
 aaa
 aaa
 aaa
@@ -140691,13 +140577,13 @@ wpz
 fqf
 nnu
 kqM
+hbx
 juP
-lmf
-lmf
+lMJ
+qjw
+qjw
 aaa
-bzi
-aaa
-aaa
+yeF
 aaa
 aaa
 aaa
@@ -140940,21 +140826,21 @@ vcF
 bio
 cxg
 tiY
-dUd
+vcF
 jza
-juP
+lrz
 mYp
 fSQ
-nHr
-gkV
-uls
+vdc
+nVz
+nVz
+nVz
 juP
-lmf
-lmf
 lMJ
-bzi
-aaa
-aaa
+gKg
+uWT
+lMJ
+yeF
 aaa
 aaa
 aaa
@@ -141199,19 +141085,19 @@ vcF
 vcF
 vcF
 juP
+qiQ
 juP
+oZO
+oZO
+juM
+juM
+juM
 juP
-juP
-nKs
-nKs
-nKs
-juP
-had
-pPv
-aaa
-bzi
 aaa
 aaa
+lMJ
+aaa
+yeF
 aaa
 aaa
 aaa
@@ -141456,7 +141342,7 @@ aaa
 aaa
 lMJ
 aaa
-aaa
+skg
 lMJ
 aaa
 aaa
@@ -141466,9 +141352,9 @@ aaa
 lMJ
 aaa
 aaa
-nYJ
+lMJ
 aaa
-aaa
+yeF
 aaa
 aaa
 aaa
@@ -141712,20 +141598,20 @@ bzi
 bzi
 bzi
 bzi
+jHD
 bzi
 bzi
 bzi
-bzi
+lMJ
+lMJ
+lMJ
 lMJ
 lMJ
 nYJ
 bzi
 bzi
-bzi
-bzi
-bzi
-aaa
-aaa
+yeF
+yeF
 aaa
 aaa
 aaa
@@ -141974,9 +141860,9 @@ aaa
 aaa
 aaa
 aaa
+lMJ
 aaa
-aaa
-aaa
+lMJ
 aaa
 aaa
 aaa
@@ -142231,9 +142117,9 @@ aaa
 aaa
 aaa
 aaa
+lMJ
 aaa
-aaa
-aaa
+lMJ
 aaa
 aaa
 aaa
@@ -142488,9 +142374,9 @@ aaa
 aaa
 aaa
 aaa
+lMJ
 aaa
-aaa
-aaa
+lMJ
 aaa
 aaa
 aaa
@@ -142743,12 +142629,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vcA
+yeF
+yeF
+yeF
+yeF
+yeF
 aaa
 aaa
 aaa

--- a/_maps/map_files/Austation/Austation.dmm
+++ b/_maps/map_files/Austation/Austation.dmm
@@ -7375,14 +7375,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/storage_wing)
-"aHl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "aHr" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig Control";
@@ -8539,13 +8531,6 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
-"aMu" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Reactor to Cooling Loop"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "aMv" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -16588,10 +16573,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bur" = (
-/obj/structure/grille/broken,
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
 "buy" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
@@ -32827,6 +32808,16 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"cGU" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "cGV" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -40768,6 +40759,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"dMN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "dNQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -41358,11 +41357,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/genetics)
-"eaZ" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "ebi" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -41682,6 +41676,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"ekP" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 6
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "ekU" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -41841,12 +41845,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"eqe" = (
-/obj/machinery/door/poddoor{
-	id = "au_nuclear_vent"
-	},
-/turf/open/space/basic,
-/area/engine/engineering/reactor_core)
 "eqi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -45939,13 +45937,6 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"gar" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "gbi" = (
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 8
@@ -46759,16 +46750,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"gxg" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "gxu" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -52584,6 +52565,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"iOw" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "iOJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -54996,16 +54984,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"jJY" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 6
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "jKa" = (
 /obj/structure/table,
 /obj/item/folder/red{
@@ -56810,6 +56788,13 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
+"kxo" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Reactor to Cooling Loop"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "kxp" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -58300,15 +58285,14 @@
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
 "leW" = (
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	dir = 4;
-	name = "Emergency Coolent Purge"
-	},
 /obj/machinery/power/terminal{
 	dir = 1
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
@@ -59727,6 +59711,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"lNg" = (
+/obj/machinery/door/poddoor{
+	id = "au_nuclear_vent"
+	},
+/turf/open/space/basic,
+/area/engine/engineering/reactor_core)
 "lNr" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -60502,13 +60492,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"maV" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "mbm" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -60517,10 +60500,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
-"mbz" = (
-/obj/structure/grille/broken,
-/turf/open/space/basic,
-/area/space)
 "mco" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -61026,12 +61005,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"mrb" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "mrh" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
@@ -61602,10 +61575,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
-"mBn" = (
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
 "mBD" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -62057,6 +62026,11 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"mKQ" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "mLm" = (
 /obj/item/radio/intercom{
 	pixel_x = -28
@@ -62089,6 +62063,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"mLL" = (
+/obj/structure/grille/broken,
+/turf/open/space/basic,
+/area/space)
 "mMy" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -65790,6 +65768,16 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
+"oek" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 5
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "oeD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -69204,6 +69192,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"ppO" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "ppP" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -71107,8 +71102,9 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
 "qiQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	dir = 4;
+	name = "Emergency Coolant Purge"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
@@ -71455,6 +71451,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"qrD" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 10
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "qsg" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -73898,6 +73904,16 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"rqs" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 9
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "rqw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -74037,6 +74053,15 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
+"rte" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "rtl" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -75096,16 +75121,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"rSh" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 5
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "rSk" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -76599,12 +76614,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
-"syd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/pool,
-/area/engine/engineering/reactor_core)
 "syj" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -77986,6 +77995,12 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"taz" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "tbn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -78776,11 +78791,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
-"tqt" = (
-/obj/effect/spawner/structure/window/plasma/reinforced/shutter,
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "tqw" = (
 /obj/structure/table,
 /obj/item/radio/intercom{
@@ -78831,14 +78841,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"trK" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Cooling Loop to Reactor"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "trL" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -80172,16 +80174,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"tUy" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "tUN" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = -32
@@ -83770,6 +83762,16 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"vsk" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "vsm" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L10"
@@ -84121,16 +84123,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"vzi" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 9
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "vzw" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/delivery,
@@ -84358,6 +84350,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
+"vEY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/pool,
+/area/engine/engineering/reactor_core)
 "vFg" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -86651,16 +86649,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"wAf" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 10
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "wAO" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -87150,6 +87138,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
+"wOy" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Cooling Loop to Reactor"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "wOE" = (
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
@@ -87450,6 +87446,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"wSe" = (
+/obj/structure/grille/broken,
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
 "wSn" = (
 /obj/structure/rack,
 /obj/item/circuitboard/machine/telecomms/bus,
@@ -87714,15 +87714,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain/private)
-"wYo" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "wYy" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -88073,6 +88064,15 @@
 	},
 /turf/open/pool,
 /area/engine/engineering/reactor_core)
+"xgD" = (
+/obj/effect/spawner/structure/window/plasma/reinforced/shutter,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
+"xgT" = (
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
 "xht" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -89471,6 +89471,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"xJa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "xJe" = (
 /obj/machinery/newscaster{
 	pixel_y = -30
@@ -137570,8 +137576,8 @@ aaa
 aaf
 nYJ
 bzi
-mBn
-mBn
+xgT
+xgT
 aaa
 aaa
 aaa
@@ -137828,7 +137834,7 @@ lMJ
 aaa
 lMJ
 aaa
-mBn
+xgT
 aaa
 aaa
 aaa
@@ -138085,7 +138091,7 @@ lMJ
 aaa
 lMJ
 aaa
-mBn
+xgT
 aaa
 aaa
 aaa
@@ -138334,15 +138340,15 @@ iDf
 rzC
 wpz
 wpz
-gar
-tUy
-maV
+iOw
+cGU
+ppO
 juP
 lMJ
-jJY
-rSh
+ekP
+oek
 lMJ
-mBn
+xgT
 aaa
 aaa
 aaa
@@ -138593,13 +138599,13 @@ nVz
 nVz
 udJ
 wpz
-aHl
+dMN
 juP
 lMJ
-gxg
-gxg
+vsk
+vsk
 aaa
-mBn
+xgT
 aaa
 aaa
 aaa
@@ -138848,15 +138854,15 @@ leW
 yeF
 xgA
 jJK
-syd
+vEY
 nVz
 qMQ
 oZO
 lMJ
-gxg
-gxg
+vsk
+vsk
 lMJ
-mBn
+xgT
 aaa
 aaa
 aaa
@@ -139110,10 +139116,10 @@ nVz
 qMQ
 oZO
 pPv
-gxg
-gxg
+vsk
+vsk
 aaa
-mBn
+xgT
 aaa
 aaa
 aaa
@@ -139367,10 +139373,10 @@ nVz
 qMQ
 oZO
 lMJ
-gxg
-gxg
+vsk
+vsk
 lMJ
-mBn
+xgT
 aaa
 aaa
 aaa
@@ -139621,13 +139627,13 @@ tGh
 uVm
 tGh
 uSl
-aMu
-tqt
+kxo
+xgD
 sdz
-vzi
-gxg
+rqs
+vsk
 aaa
-mBn
+xgT
 aaa
 aaa
 aaa
@@ -139875,16 +139881,16 @@ xdc
 nVz
 ucJ
 nVz
-qiQ
+xJa
 nVz
-wYo
-trK
-tqt
+rte
+wOy
+xgD
 sdz
-rSh
-gxg
+oek
+vsk
 aaa
-mBn
+xgT
 aaa
 aaa
 aaa
@@ -140138,10 +140144,10 @@ uls
 qMQ
 oZO
 lMJ
-gxg
-gxg
+vsk
+vsk
 aaa
-mBn
+xgT
 aaa
 aaa
 aaa
@@ -140395,10 +140401,10 @@ uls
 qMQ
 oZO
 lMJ
-gxg
-gxg
+vsk
+vsk
 aaa
-bur
+wSe
 aaa
 aaa
 aaa
@@ -140649,13 +140655,13 @@ wpz
 fqf
 nnu
 kqM
-eaZ
+mKQ
 juP
 lMJ
-gxg
-gxg
+vsk
+vsk
 aaa
-mBn
+xgT
 aaa
 aaa
 aaa
@@ -140903,16 +140909,16 @@ jza
 skg
 mYp
 fSQ
-mrb
+taz
 nVz
 nVz
 qMQ
 juP
 lMJ
-wAf
-vzi
+qrD
+rqs
 lMJ
-mBn
+xgT
 aaa
 aaa
 aaa
@@ -141161,15 +141167,15 @@ uCQ
 juP
 oZO
 oZO
-eqe
-eqe
-eqe
+lNg
+lNg
+lNg
 juP
 aaa
 aaa
 lMJ
 aaa
-mBn
+xgT
 aaa
 aaa
 aaa
@@ -141426,7 +141432,7 @@ aaa
 aaa
 lMJ
 aaa
-mBn
+xgT
 aaa
 aaa
 aaa
@@ -141682,8 +141688,8 @@ lMJ
 nYJ
 bzi
 bzi
-mBn
-mBn
+xgT
+xgT
 aaa
 aaa
 aaa
@@ -142701,12 +142707,12 @@ aaa
 aaa
 aaa
 aaa
-mbz
-mBn
-mBn
-mBn
-mBn
-mBn
+mLL
+xgT
+xgT
+xgT
+xgT
+xgT
 aaa
 aaa
 aaa

--- a/_maps/map_files/Austation/Austation.dmm
+++ b/_maps/map_files/Austation/Austation.dmm
@@ -7375,6 +7375,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/storage_wing)
+"aHl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "aHr" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig Control";
@@ -8217,9 +8225,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aKR" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Atmospherics to Reactor"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "aLf" = (
@@ -8530,6 +8539,13 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
+"aMu" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Reactor to Cooling Loop"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "aMv" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -10257,12 +10273,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "aTs" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 10
 	},
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/space/basic,
+/area/space)
 "aTD" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -13235,10 +13250,9 @@
 /area/hallway/secondary/entry)
 "beI" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/space,
 /area/space/nearstation)
 "beK" = (
@@ -13726,10 +13740,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"bgQ" = (
-/obj/effect/turf_decal/stripes/white/line,
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "bgY" = (
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
@@ -16578,6 +16588,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bur" = (
+/obj/structure/grille/broken,
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
 "buy" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
@@ -19238,6 +19252,9 @@
 /area/engine/atmos)
 "bHv" = (
 /obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/space,
 /area/space/nearstation)
@@ -23150,7 +23167,7 @@
 /area/hallway/primary/central)
 "bVi" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/purple{
+/obj/machinery/atmospherics/pipe/manifold/brown/visible{
 	dir = 8
 	},
 /turf/open/floor/engine,
@@ -38327,11 +38344,10 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "dhz" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 10
-	},
-/turf/open/space/basic,
-/area/space)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/turf/open/space,
+/area/space/nearstation)
 "dhA" = (
 /obj/machinery/washing_machine,
 /obj/structure/sign/poster/official/random{
@@ -41037,7 +41053,7 @@
 /area/maintenance/starboard)
 "dUd" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/machinery/atmospherics/pipe/simple/brown/visible,
 /turf/closed/wall/r_wall,
 /area/engine/engineering/reactor_control)
 "dUl" = (
@@ -41342,6 +41358,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/genetics)
+"eaZ" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "ebi" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -41820,6 +41841,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"eqe" = (
+/obj/machinery/door/poddoor{
+	id = "au_nuclear_vent"
+	},
+/turf/open/space/basic,
+/area/engine/engineering/reactor_core)
 "eqi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -42573,9 +42600,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/structure/cable/white{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Atmospherics to Reactor"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering/reactor_control)
@@ -43022,12 +43051,6 @@
 	dir = 5
 	},
 /area/crew_quarters/heads/hor)
-"eOm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/pool,
-/area/engine/engineering/reactor_core)
 "eOs" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -43360,12 +43383,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "eZo" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/purple{
+	dir = 1
 	},
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/space/basic,
+/area/space)
 "eZs" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Quiet Room"
@@ -45530,6 +45552,9 @@
 	},
 /obj/machinery/power/apc/auto_name/north,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "fTV" = (
@@ -45914,6 +45939,13 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"gar" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "gbi" = (
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 8
@@ -46303,7 +46335,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
-/obj/machinery/meter,
 /turf/open/space,
 /area/space/nearstation)
 "gld" = (
@@ -46728,6 +46759,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"gxg" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "gxu" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -47314,16 +47355,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"gKg" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 10
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "gKr" = (
 /obj/structure/table/wood,
 /obj/machinery/light_switch{
@@ -47791,9 +47822,13 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "gRQ" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
-/turf/closed/wall/r_wall,
-/area/engine/engineering/reactor_control)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/space,
+/area/space/nearstation)
 "gSi" = (
 /obj/machinery/light/small,
 /obj/structure/disposalpipe/segment{
@@ -48211,10 +48246,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"hbx" = (
-/obj/machinery/light,
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "hbU" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon{
@@ -49190,10 +49221,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"hsx" = (
-/obj/structure/grille/broken,
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
 "hsP" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -51457,13 +51484,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"iqZ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Cooling Loop to Reactor"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "irb" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -51952,6 +51972,21 @@
 	},
 /turf/open/floor/plating,
 /area/science/nanite)
+"iDf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "iDq" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -51979,6 +52014,9 @@
 /obj/structure/cable/white,
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
@@ -53330,9 +53368,6 @@
 /turf/open/space/basic,
 /area/space)
 "jef" = (
-/obj/machinery/atmospherics/components/binary/valve/digital/on/layer3{
-	name = "Reactor Scrubbers to Main Scrubber"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -54228,12 +54263,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"juM" = (
-/obj/machinery/door/poddoor{
-	id = "au_nuclear_vent"
-	},
-/turf/open/space/basic,
-/area/engine/engineering/reactor_core)
 "juP" = (
 /turf/closed/wall/r_wall,
 /area/engine/engineering/reactor_core)
@@ -54427,6 +54456,9 @@
 /obj/item/sealant,
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
@@ -54897,10 +54929,9 @@
 	},
 /area/maintenance/aft)
 "jHD" = (
-/obj/structure/lattice,
-/obj/structure/grille/broken,
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/closed/wall/r_wall,
-/area/space/nearstation)
+/area/engine/engineering/reactor_control)
 "jHS" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -54965,6 +54996,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"jJY" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 6
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "jKa" = (
 /obj/structure/table,
 /obj/item/folder/red{
@@ -56128,12 +56169,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "klT" = (
+/obj/structure/lattice,
 /obj/structure/grille/broken,
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering/reactor_core)
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
 "klV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool,
@@ -56562,10 +56601,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"ksv" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "ksY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -57299,6 +57334,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/pool/ladder{
+	dir = 2;
+	pixel_y = 17
+	},
 /turf/open/pool,
 /area/engine/engineering/reactor_core)
 "kGW" = (
@@ -57641,11 +57680,11 @@
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "kOU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+/obj/structure/grille/broken,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced/shutter,
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering/reactor_core)
 "kOV" = (
 /obj/effect/turf_decal/stripes/line{
@@ -57828,16 +57867,10 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "kSU" = (
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	dir = 4;
-	name = "Emergency Coolent Purge"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
 	},
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
+/obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "kSY" = (
@@ -58267,8 +58300,15 @@
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
 "leW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	dir = 4;
+	name = "Emergency Coolent Purge"
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
@@ -58720,8 +58760,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/plumbing)
 "lrz" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
@@ -58827,6 +58867,9 @@
 "ltD" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable/white,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "luo" = (
@@ -59341,6 +59384,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"lGj" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/turf/open/floor/carpet/royalblack,
+/area/engine/engineering/reactor_control)
 "lGq" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -60452,6 +60502,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"maV" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "mbm" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -60460,6 +60517,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
+"mbz" = (
+/obj/structure/grille/broken,
+/turf/open/space/basic,
+/area/space)
 "mco" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -60884,6 +60945,12 @@
 "moS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/closet/secure_closet/engineering_welding,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/airalarm{
+	pixel_y = 22
+	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "mpm" = (
@@ -60895,16 +60962,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"mpD" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 6
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "mpZ" = (
 /obj/structure/table/optable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -60969,6 +61026,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"mrb" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "mrh" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
@@ -61539,6 +61602,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
+"mBn" = (
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
 "mBD" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -62326,13 +62393,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"mSK" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/machinery/light,
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "mTr" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -63485,6 +63545,9 @@
 "npK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
@@ -66826,7 +66889,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "oAh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -67700,6 +67762,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering/reactor_control)
 "oQQ" = (
@@ -71044,10 +71107,9 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
 "qiQ" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "qiT" = (
@@ -71056,16 +71118,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering/reactor_control)
-"qjw" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "qjB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -72443,9 +72495,7 @@
 /turf/open/floor/plating,
 /area/medical/sleeper)
 "qMQ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Reactor to Cooling Loop"
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "qMR" = (
@@ -72940,7 +72990,6 @@
 /area/security/nuke_storage)
 "qXg" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
@@ -73249,15 +73298,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"rcq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "rcL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -74054,10 +74094,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering/reactor_control)
 "ruF" = (
@@ -74285,6 +74325,9 @@
 "rzC" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
@@ -75053,6 +75096,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"rSh" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 5
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "rSk" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -75909,16 +75962,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"siB" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 5
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "siF" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -76017,11 +76060,11 @@
 /turf/open/floor/wood,
 /area/library)
 "skg" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
 	dir = 8
 	},
-/turf/open/floor/plating/airless,
-/area/space)
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "skh" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/white,
@@ -76556,6 +76599,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
+"syd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/pool,
+/area/engine/engineering/reactor_core)
 "syj" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -78263,11 +78312,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"tiy" = (
-/obj/effect/spawner/structure/window/plasma/reinforced/shutter,
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "tiC" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -78732,6 +78776,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
+"tqt" = (
+/obj/effect/spawner/structure/window/plasma/reinforced/shutter,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "tqw" = (
 /obj/structure/table,
 /obj/item/radio/intercom{
@@ -78782,6 +78831,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"trK" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Cooling Loop to Reactor"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "trL" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -79421,12 +79478,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "tFn" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering/reactor_control)
@@ -80115,6 +80172,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"tUy" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "tUN" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = -32
@@ -80557,7 +80624,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "udJ" = (
-/obj/effect/turf_decal/stripes/white/corner{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /turf/open/floor/engine,
@@ -81479,12 +81546,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"uwa" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "uwo" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -81710,8 +81771,8 @@
 /area/hallway/primary/port)
 "uCz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
@@ -81727,17 +81788,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uCQ" = (
-/obj/machinery/pool/filter{
-	pixel_y = -18
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/spawner/structure/window/plasma/reinforced/shutter,
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
@@ -82725,16 +82778,6 @@
 	},
 /turf/closed/wall,
 /area/aisat)
-"uWT" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 9
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "uXd" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -83080,9 +83123,11 @@
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "vcA" = (
-/obj/structure/grille/broken,
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering/reactor_core)
 "vcF" = (
 /turf/closed/wall/r_wall,
 /area/engine/engineering/reactor_control)
@@ -83095,12 +83140,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"vdc" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "vdi" = (
 /obj/structure/sink{
 	dir = 4;
@@ -84082,6 +84121,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"vzi" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 9
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "vzw" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/delivery,
@@ -85910,11 +85959,6 @@
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
-"wiP" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/effect/turf_decal/box,
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "wiQ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -86607,6 +86651,16 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"wAf" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 10
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "wAO" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -87618,14 +87672,6 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/dorms)
-"wXe" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/box,
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "wXh" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -87668,6 +87714,15 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain/private)
+"wYo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "wYy" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -87802,6 +87857,9 @@
 "xdc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
@@ -88610,10 +88668,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/purple{
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/brown/visible{
 	dir = 8
 	},
-/obj/machinery/camera/autoname,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "xtO" = (
@@ -90512,9 +90573,20 @@
 /turf/open/floor/carpet/green,
 /area/lawoffice)
 "yeF" = (
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
+/obj/machinery/pool/filter{
+	pixel_y = -18
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "yeO" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -135679,9 +135751,9 @@ aaf
 bFY
 aaf
 bJb
-aTs
 beI
 bHv
+dhz
 fwu
 pTP
 bWn
@@ -135939,7 +136011,7 @@ bCA
 gJs
 bFZ
 bAR
-eZo
+gkV
 pTP
 gvG
 mqr
@@ -136196,7 +136268,7 @@ bUI
 bVN
 bXr
 bAR
-eZo
+gkV
 pTP
 bWn
 leG
@@ -136453,7 +136525,7 @@ bUJ
 bVO
 bUJ
 bAR
-eZo
+gkV
 pTP
 bWn
 uID
@@ -136710,7 +136782,7 @@ bUJ
 bVP
 bXs
 bAR
-eZo
+gkV
 pTP
 bWn
 mhC
@@ -136967,7 +137039,7 @@ bAR
 bAR
 bAR
 bAR
-gkV
+gRQ
 ccZ
 ccY
 lBp
@@ -137224,7 +137296,7 @@ aaf
 aaf
 aaf
 aaf
-eZo
+gkV
 pTP
 bWn
 leG
@@ -137481,7 +137553,7 @@ aaa
 aaa
 aaa
 aaa
-eZo
+gkV
 pTP
 bWn
 mqr
@@ -137498,8 +137570,8 @@ aaa
 aaf
 nYJ
 bzi
-yeF
-yeF
+mBn
+mBn
 aaa
 aaa
 aaa
@@ -137744,7 +137816,7 @@ gvG
 leG
 aaf
 aaa
-klT
+kOU
 bzj
 aai
 bzj
@@ -137756,7 +137828,7 @@ lMJ
 aaa
 lMJ
 aaa
-yeF
+mBn
 aaa
 aaa
 aaa
@@ -138001,7 +138073,7 @@ vbo
 nrr
 vcF
 juP
-kOU
+kSU
 juP
 oZO
 oZO
@@ -138013,7 +138085,7 @@ lMJ
 aaa
 lMJ
 aaa
-yeF
+mBn
 aaa
 aaa
 aaa
@@ -138258,19 +138330,19 @@ bec
 mqk
 had
 iEb
-xed
+iDf
 rzC
-nVz
-nVz
-bgQ
-wXe
-wiP
+wpz
+wpz
+gar
+tUy
+maV
 juP
 lMJ
-mpD
-siB
+jJY
+rSh
 lMJ
-yeF
+mBn
 aaa
 aaa
 aaa
@@ -138520,14 +138592,14 @@ tPl
 nVz
 nVz
 udJ
-uwa
-mSK
+wpz
+aHl
 juP
 lMJ
-qjw
-qjw
+gxg
+gxg
 aaa
-yeF
+mBn
 aaa
 aaa
 aaa
@@ -138772,19 +138844,19 @@ xAu
 jfH
 juz
 ltD
-kSU
-uCQ
+leW
+yeF
 xgA
 jJK
-eOm
+syd
 nVz
-nVz
+qMQ
 oZO
 lMJ
-qjw
-qjw
+gxg
+gxg
 lMJ
-yeF
+mBn
 aaa
 aaa
 aaa
@@ -139035,13 +139107,13 @@ kGL
 wds
 rSM
 nVz
-nVz
+qMQ
 oZO
 pPv
-qjw
-qjw
+gxg
+gxg
 aaa
-yeF
+mBn
 aaa
 aaa
 aaa
@@ -139285,20 +139357,20 @@ tFn
 oAh
 jef
 qXg
-nVz
-leW
+lrz
+qiQ
 dkd
 iem
 qOe
 tzk
 nVz
-nVz
+qMQ
 oZO
 lMJ
-qjw
-qjw
+gxg
+gxg
 lMJ
-yeF
+mBn
 aaa
 aaa
 aaa
@@ -139536,8 +139608,8 @@ aaa
 aaa
 aaa
 bzi
-dhz
-gRQ
+eZo
+jHD
 rTZ
 hdT
 eFx
@@ -139549,13 +139621,13 @@ tGh
 uVm
 tGh
 uSl
-qMQ
-tiy
+aMu
+tqt
 sdz
-uWT
-qjw
+vzi
+gxg
 aaa
-yeF
+mBn
 aaa
 aaa
 aaa
@@ -139793,7 +139865,7 @@ aaa
 aaa
 aaa
 bzi
-aaa
+vfp
 vcF
 jNa
 xrK
@@ -139803,16 +139875,16 @@ xdc
 nVz
 ucJ
 nVz
-leW
+qiQ
 nVz
-rcq
-iqZ
-tiy
+wYo
+trK
+tqt
 sdz
-siB
-qjw
+rSh
+gxg
 aaa
-yeF
+mBn
 aaa
 aaa
 aaa
@@ -140050,10 +140122,10 @@ aaa
 aaa
 aaa
 bzi
-aaa
-vcF
+aTs
+jHD
 oQM
-wnm
+lGj
 jSa
 dUd
 xsO
@@ -140063,13 +140135,13 @@ wGL
 auY
 nVz
 uls
-nVz
+qMQ
 oZO
 lMJ
-qjw
-qjw
+gxg
+gxg
 aaa
-yeF
+mBn
 aaa
 aaa
 aaa
@@ -140315,18 +140387,18 @@ mjB
 vcF
 fTQ
 lgO
-ksv
+qMQ
 nVz
 nHr
 nVz
 uls
-nVz
+qMQ
 oZO
 lMJ
-qjw
-qjw
+gxg
+gxg
 aaa
-hsx
+bur
 aaa
 aaa
 aaa
@@ -140577,13 +140649,13 @@ wpz
 fqf
 nnu
 kqM
-hbx
+eaZ
 juP
 lMJ
-qjw
-qjw
+gxg
+gxg
 aaa
-yeF
+mBn
 aaa
 aaa
 aaa
@@ -140828,19 +140900,19 @@ cxg
 tiY
 vcF
 jza
-lrz
+skg
 mYp
 fSQ
-vdc
+mrb
 nVz
 nVz
-nVz
+qMQ
 juP
 lMJ
-gKg
-uWT
+wAf
+vzi
 lMJ
-yeF
+mBn
 aaa
 aaa
 aaa
@@ -141085,19 +141157,19 @@ vcF
 vcF
 vcF
 juP
-qiQ
+uCQ
 juP
 oZO
 oZO
-juM
-juM
-juM
+eqe
+eqe
+eqe
 juP
 aaa
 aaa
 lMJ
 aaa
-yeF
+mBn
 aaa
 aaa
 aaa
@@ -141342,7 +141414,7 @@ aaa
 aaa
 lMJ
 aaa
-skg
+vcA
 lMJ
 aaa
 aaa
@@ -141354,7 +141426,7 @@ aaa
 aaa
 lMJ
 aaa
-yeF
+mBn
 aaa
 aaa
 aaa
@@ -141598,7 +141670,7 @@ bzi
 bzi
 bzi
 bzi
-jHD
+klT
 bzi
 bzi
 bzi
@@ -141610,8 +141682,8 @@ lMJ
 nYJ
 bzi
 bzi
-yeF
-yeF
+mBn
+mBn
 aaa
 aaa
 aaa
@@ -142629,12 +142701,12 @@ aaa
 aaa
 aaa
 aaa
-vcA
-yeF
-yeF
-yeF
-yeF
-yeF
+mbz
+mBn
+mBn
+mBn
+mBn
+mBn
 aaa
 aaa
 aaa

--- a/_maps/map_files/Austation/Austation.dmm
+++ b/_maps/map_files/Austation/Austation.dmm
@@ -16323,6 +16323,10 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"btb" = (
+/obj/structure/grille/broken,
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
 "btc" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced,
@@ -32808,16 +32812,6 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"cGU" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "cGV" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -36021,6 +36015,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"cVp" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 6
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "cVx" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -40759,14 +40763,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"dMN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "dNQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -41676,16 +41672,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"ekP" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 6
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "ekU" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -44634,6 +44620,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"fzu" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "fzK" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -45399,6 +45395,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"fPr" = (
+/obj/effect/spawner/structure/window/plasma/reinforced/shutter,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "fPx" = (
 /obj/machinery/light{
 	dir = 4
@@ -45806,6 +45807,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"fXj" = (
+/obj/structure/grille/broken,
+/turf/open/space/basic,
+/area/space)
 "fXS" = (
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -47896,6 +47901,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
+"gTX" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "gUb" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = 32
@@ -49156,6 +49166,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/plumbing)
+"hrG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "hrI" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -50213,6 +50229,12 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"hPu" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "hPH" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -50775,6 +50797,12 @@
 	dir = 5
 	},
 /turf/open/pool,
+/area/engine/engineering/reactor_core)
+"ieT" = (
+/obj/machinery/door/poddoor{
+	id = "au_nuclear_vent"
+	},
+/turf/open/space/basic,
 /area/engine/engineering/reactor_core)
 "ifa" = (
 /obj/structure/closet/emcloset,
@@ -52565,13 +52593,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"iOw" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "iOJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -54797,6 +54818,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"jEK" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "jEM" = (
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /obj/item/reagent_containers/food/snacks/grown/watermelon,
@@ -55287,8 +55318,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	name = "moderator valve"
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Atmospherics to Moderator"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering/reactor_control)
@@ -56788,13 +56819,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
-"kxo" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Reactor to Cooling Loop"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "kxp" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -57101,6 +57125,13 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"kCf" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "kCq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
@@ -58521,6 +58552,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"lkH" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 9
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "lkO" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -59711,12 +59752,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"lNg" = (
-/obj/machinery/door/poddoor{
-	id = "au_nuclear_vent"
-	},
-/turf/open/space/basic,
-/area/engine/engineering/reactor_core)
 "lNr" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -62026,11 +62061,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"mKQ" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "mLm" = (
 /obj/item/radio/intercom{
 	pixel_x = -28
@@ -62063,10 +62093,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"mLL" = (
-/obj/structure/grille/broken,
-/turf/open/space/basic,
-/area/space)
 "mMy" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -64281,6 +64307,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"nES" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Cooling Loop to Reactor"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "nFa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -64611,6 +64645,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms/room_a)
+"nMa" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Reactor to Cooling Loop"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "nMd" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 28
@@ -65768,16 +65809,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
-"oek" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 5
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "oeD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -68641,6 +68672,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"pee" = (
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
 "peF" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -69192,13 +69227,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"ppO" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "ppP" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -71451,16 +71479,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"qrD" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 10
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "qsg" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -73411,6 +73429,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"reU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "rfc" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -73872,6 +73898,16 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"rph" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 5
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "rpC" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/blue{
@@ -73904,16 +73940,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"rqs" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 9
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "rqw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -74053,15 +74079,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
-"rte" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "rtl" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -76132,6 +76149,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"skU" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
+	dir = 10
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "slb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -77995,12 +78022,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"taz" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "tbn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -81564,6 +81585,15 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/port)
+"uwU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "uxf" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/structure/closet/crate/goldcrate,
@@ -83222,6 +83252,13 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"vfu" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/engine/engineering/reactor_core)
 "vfy" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -83762,16 +83799,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"vsk" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "vsm" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L10"
@@ -84350,12 +84377,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
-"vEY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/pool,
-/area/engine/engineering/reactor_core)
 "vFg" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -87138,14 +87159,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"wOy" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Cooling Loop to Reactor"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "wOE" = (
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
@@ -87446,10 +87459,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"wSe" = (
-/obj/structure/grille/broken,
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
 "wSn" = (
 /obj/structure/rack,
 /obj/item/circuitboard/machine/telecomms/bus,
@@ -88064,15 +88073,6 @@
 	},
 /turf/open/pool,
 /area/engine/engineering/reactor_core)
-"xgD" = (
-/obj/effect/spawner/structure/window/plasma/reinforced/shutter,
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
-"xgT" = (
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
 "xht" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -89471,12 +89471,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"xJa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering/reactor_core)
 "xJe" = (
 /obj/machinery/newscaster{
 	pixel_y = -30
@@ -89993,6 +89987,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
+"xTi" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/pool,
+/area/engine/engineering/reactor_core)
 "xTj" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -137576,8 +137576,8 @@ aaa
 aaf
 nYJ
 bzi
-xgT
-xgT
+pee
+pee
 aaa
 aaa
 aaa
@@ -137834,7 +137834,7 @@ lMJ
 aaa
 lMJ
 aaa
-xgT
+pee
 aaa
 aaa
 aaa
@@ -138091,7 +138091,7 @@ lMJ
 aaa
 lMJ
 aaa
-xgT
+pee
 aaa
 aaa
 aaa
@@ -138340,15 +138340,15 @@ iDf
 rzC
 wpz
 wpz
-iOw
-cGU
-ppO
+kCf
+jEK
+vfu
 juP
 lMJ
-ekP
-oek
+cVp
+rph
 lMJ
-xgT
+pee
 aaa
 aaa
 aaa
@@ -138599,13 +138599,13 @@ nVz
 nVz
 udJ
 wpz
-dMN
+reU
 juP
 lMJ
-vsk
-vsk
+fzu
+fzu
 aaa
-xgT
+pee
 aaa
 aaa
 aaa
@@ -138854,15 +138854,15 @@ leW
 yeF
 xgA
 jJK
-vEY
+xTi
 nVz
 qMQ
 oZO
 lMJ
-vsk
-vsk
+fzu
+fzu
 lMJ
-xgT
+pee
 aaa
 aaa
 aaa
@@ -139116,10 +139116,10 @@ nVz
 qMQ
 oZO
 pPv
-vsk
-vsk
+fzu
+fzu
 aaa
-xgT
+pee
 aaa
 aaa
 aaa
@@ -139373,10 +139373,10 @@ nVz
 qMQ
 oZO
 lMJ
-vsk
-vsk
+fzu
+fzu
 lMJ
-xgT
+pee
 aaa
 aaa
 aaa
@@ -139627,13 +139627,13 @@ tGh
 uVm
 tGh
 uSl
-kxo
-xgD
+nMa
+fPr
 sdz
-rqs
-vsk
+lkH
+fzu
 aaa
-xgT
+pee
 aaa
 aaa
 aaa
@@ -139881,16 +139881,16 @@ xdc
 nVz
 ucJ
 nVz
-xJa
+hrG
 nVz
-rte
-wOy
-xgD
+uwU
+nES
+fPr
 sdz
-oek
-vsk
+rph
+fzu
 aaa
-xgT
+pee
 aaa
 aaa
 aaa
@@ -140144,10 +140144,10 @@ uls
 qMQ
 oZO
 lMJ
-vsk
-vsk
+fzu
+fzu
 aaa
-xgT
+pee
 aaa
 aaa
 aaa
@@ -140401,10 +140401,10 @@ uls
 qMQ
 oZO
 lMJ
-vsk
-vsk
+fzu
+fzu
 aaa
-wSe
+btb
 aaa
 aaa
 aaa
@@ -140655,13 +140655,13 @@ wpz
 fqf
 nnu
 kqM
-mKQ
+gTX
 juP
 lMJ
-vsk
-vsk
+fzu
+fzu
 aaa
-xgT
+pee
 aaa
 aaa
 aaa
@@ -140909,16 +140909,16 @@ jza
 skg
 mYp
 fSQ
-taz
+hPu
 nVz
 nVz
 qMQ
 juP
 lMJ
-qrD
-rqs
+skU
+lkH
 lMJ
-xgT
+pee
 aaa
 aaa
 aaa
@@ -141167,15 +141167,15 @@ uCQ
 juP
 oZO
 oZO
-lNg
-lNg
-lNg
+ieT
+ieT
+ieT
 juP
 aaa
 aaa
 lMJ
 aaa
-xgT
+pee
 aaa
 aaa
 aaa
@@ -141432,7 +141432,7 @@ aaa
 aaa
 lMJ
 aaa
-xgT
+pee
 aaa
 aaa
 aaa
@@ -141688,8 +141688,8 @@ lMJ
 nYJ
 bzi
 bzi
-xgT
-xgT
+pee
+pee
 aaa
 aaa
 aaa
@@ -142707,12 +142707,12 @@ aaa
 aaa
 aaa
 aaa
-mLL
-xgT
-xgT
-xgT
-xgT
-xgT
+fXj
+pee
+pee
+pee
+pee
+pee
 aaa
 aaa
 aaa


### PR DESCRIPTION
## About The Pull Request

Expands the reactor room to be more spread out and less messy, only uses one layer now.


![reactor](https://user-images.githubusercontent.com/59686430/96006642-6ef83200-0e89-11eb-8535-3ad06e445fbc.PNG)

## Why It's Good For The Game

The old layout worked but was pretty messy in comparison, it also wasn't even wired to the SMES bank

## Changelog
:cl:
tweak: Reactor room is now larger and more spread out
fix: Reactor is now wired to the grid properly
/:cl:
