### PR TITLE
Adds fuel rods to cargo console

### DIFF
--- a/austation/code/modules/cargo/packs/packs.dm
+++ b/austation/code/modules/cargo/packs/packs.dm
@@ -9,3 +9,16 @@
     				/obj/item/slimepotion/slime/steroid)
 	crate_name = "Xenobiology Slime Steroid crate"
 	crate_type = /obj/structure/closet/crate/secure/science
+
+//Engineering
+
+/datum/supply_pack/engine/fuel_rod
+	name = "Uranium Fuel Rod crate"
+	desc = "Two additional fuel rods for use in a reactor, requires CE access to open. Caution: Radioactive"
+	cost = 4000
+	access = ACCESS_CE
+	contains = list(obj/item/twohanded/required/fuel_rod,
+					obj/item/twohanded/required/fuel_rod)
+	crate_name = "Uranium-235 Fuel Rod crate"
+	crate_type = /obj/structure/closet/crate/secure/engineering
+	dangerous = TRUE

--- a/austation/code/modules/cargo/packs/packs.dm
+++ b/austation/code/modules/cargo/packs/packs.dm
@@ -17,8 +17,8 @@
 	desc = "Two additional fuel rods for use in a reactor, requires CE access to open. Caution: Radioactive"
 	cost = 4000
 	access = ACCESS_CE
-	contains = list(obj/item/twohanded/required/fuel_rod,
-					obj/item/twohanded/required/fuel_rod)
+	contains = list(/obj/item/twohanded/required/fuel_rod,
+					/obj/item/twohanded/required/fuel_rod)
 	crate_name = "Uranium-235 Fuel Rod crate"
 	crate_type = /obj/structure/closet/crate/secure/engineering
 	dangerous = TRUE


### PR DESCRIPTION

## About The Pull Request

You can now purchase uranium fuel rods for $4000

## Why It's Good For The Game

Just in case your original rods somehow go missing. also will be useful for a future PR...

## Changelog
:cl:
add: Fuel rods can now be bought from cargo
/:cl:

