### PR TITLE
Gives miners door access on the science outpost

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -933,10 +933,13 @@
 /turf/open/floor/plating,
 /area/mine/laborcamp)
 "dL" = (
-/obj/machinery/door/airlock/external/glass,
 /obj/structure/fans/tiny,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/external{
+	name = "Science Outpost Airlock";
+	req_one_access_txt = "47,54"
 	},
 /turf/open/floor/plating,
 /area/mine/science)
@@ -992,7 +995,7 @@
 	name = "Shutters Control Button";
 	pixel_x = -6;
 	pixel_y = 24;
-	req_access_txt = "47"
+	req_one_access_txt = "47,54"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1087,7 +1090,7 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Science Outpost Airlock";
-	req_access_txt = "47"
+	req_one_access_txt = "47,54"
 	},
 /turf/open/floor/plasteel,
 /area/mine/science)
@@ -3180,15 +3183,15 @@
 /area/mine/science)
 "of" = (
 /obj/structure/barricade/wooden/crude,
-/obj/machinery/door/airlock/research{
-	name = "Robotics Lab";
-	req_access_txt = "29"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	name = "Outpost Transport Dock";
+	req_one_access_txt = "47,54"
 	},
 /turf/open/floor/plasteel,
 /area/mine/science)
@@ -3232,7 +3235,7 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Science Outpost Airlock";
-	req_access_txt = "47"
+	req_one_access_txt = "47,54"
 	},
 /turf/open/floor/plasteel,
 /area/mine/science)
@@ -3315,11 +3318,11 @@
 	dir = 8
 	},
 /obj/structure/barricade/wooden/crude,
-/obj/machinery/door/airlock/research{
-	name = "Testing Lab";
-	req_access_txt = "47"
-	},
 /obj/effect/decal/cleanable/oil/slippery,
+/obj/machinery/door/airlock/research{
+	name = "Outpost Transport Dock";
+	req_one_access_txt = "47,54"
+	},
 /turf/open/floor/plasteel,
 /area/mine/science)
 "pi" = (
@@ -3964,8 +3967,8 @@
 "xk" = (
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/door/airlock/research{
-	name = "tachyon-doppler array booth";
-	req_access_txt = "7"
+	name = "Outpost Transport Dock";
+	req_one_access_txt = "47,54"
 	},
 /turf/open/floor/plating,
 /area/mine/science)
@@ -4506,16 +4509,16 @@
 /turf/open/floor/plasteel,
 /area/mine/science)
 "Ef" = (
-/obj/machinery/door/airlock/research/glass{
-	name = "Research Division Atrium";
-	req_access_txt = "47"
-	},
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 1
+	},
+/obj/machinery/door/airlock/research{
+	name = "Outpost Transport Dock";
+	req_one_access_txt = "47,54"
 	},
 /turf/open/floor/plasteel,
 /area/mine/science)
@@ -5080,7 +5083,7 @@
 "JX" = (
 /obj/machinery/door/airlock/external{
 	name = "Science Outpost Airlock";
-	req_access_txt = "47"
+	req_one_access_txt = "47,54"
 	},
 /turf/open/floor/plating,
 /area/mine/science)
@@ -5302,15 +5305,15 @@
 /area/mine/production)
 "Mz" = (
 /obj/structure/barricade/wooden/crude,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Chemistry Lab";
-	req_access_txt = "5; 33"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
+	},
+/obj/machinery/door/airlock/research{
+	name = "Outpost Transport Dock";
+	req_one_access_txt = "47,54"
 	},
 /turf/open/floor/engine,
 /area/mine/science)
@@ -5448,7 +5451,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/airlock/research{
 	name = "Outpost Transport Dock";
-	req_access_txt = "47"
+	req_one_access_txt = "47,54"
 	},
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plasteel,
@@ -5950,12 +5953,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/research{
-	name = "Subspace Listening Lab";
-	req_access_txt = "47"
-	},
 /obj/structure/barricade/wooden/crude,
 /obj/effect/decal/cleanable/oil/slippery,
+/obj/machinery/door/airlock/research{
+	name = "Outpost Transport Dock";
+	req_one_access_txt = "47,54"
+	},
 /turf/open/floor/plasteel,
 /area/mine/science)
 "UE" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Miners were expected to open up the science outpost, south of the mining base, but as soon as they powered it up then all the doors would suddenly restrict their movement.  This pr makes all the doors take miner access in addition to science, so the miners can still get out without breaking down doors.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Miners no longer have to unga the science outpost doors, after going to the trouble of making it nice and powered.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: science outpost doors now take miner access just fine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
