### PR TITLE
Disables random events during sandbox

### DIFF
--- a/code/game/gamemodes/sandbox/sandbox.dm
+++ b/code/game/gamemodes/sandbox/sandbox.dm
@@ -6,10 +6,15 @@
 
 	announce_span = "info"
 	announce_text = "Build your own station... or just shoot each other!"
-	
+
 	allow_persistence_save = FALSE
 
 /datum/game_mode/sandbox/pre_setup()
+	//Disables Random Events
+	var/new_are = !CONFIG_GET(flag/allow_random_events)
+	CONFIG_SET(flag/allow_random_events, new_are)
+
+	//Enables player spawing
 	for(var/mob/M in GLOB.player_list)
 		M.CanBuild()
 	return 1

--- a/code/game/gamemodes/sandbox/sandbox.dm
+++ b/code/game/gamemodes/sandbox/sandbox.dm
@@ -10,11 +10,12 @@
 	allow_persistence_save = FALSE
 
 /datum/game_mode/sandbox/pre_setup()
-	//Disables Random Events
-	var/new_are = !CONFIG_GET(flag/allow_random_events)
-	CONFIG_SET(flag/allow_random_events, new_are)
 
-	//Enables player spawing
+	//austation begin -- <Disables Random Events, makes Sandbox a "Peaceful" Mode>
+	CONFIG_SET(flag/allow_random_events, FALSE)
+	//austation end
+
+	//Enables player item spawing
 	for(var/mob/M in GLOB.player_list)
 		M.CanBuild()
 	return 1


### PR DESCRIPTION
## About The Pull Request

Random events are now disabled during sandbox mode. Sets the allow_random_events config option to false at the start the game mode. Can be reenabled under Server tab or commented out if needed.     

## Why It's Good For The Game

- Makes sandbox peaceful 
- Removes the annoyince of metorites, anomalies, power-outs and ect so players can focus on their projects or other.
- Antags are removed from a non-antag mode. 

## Changelog
:cl:
tweak: Random events are now disabled by default on Sandbox mode. 
/:cl:
