### PR TITLE
Restart votes doesn't ignore deadmins anymore

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -159,7 +159,7 @@ SUBSYSTEM_DEF(vote)
 						C.post_status("shuttle")
 	if(restart)
 		var/active_admins = 0
-		for(var/client/C in GLOB.admins)
+		for(var/client/C in GLOB.admins+GLOB.deadmins)
 			if(!C.is_afk() && check_rights_for(C, R_SERVER))
 				active_admins = 1
 				break

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -159,7 +159,7 @@ SUBSYSTEM_DEF(vote)
 						C.post_status("shuttle")
 	if(restart)
 		var/active_admins = 0
-		for(var/client/C in GLOB.admins+GLOB.deadmins)
+		for(var/client/C in GLOB.admins+GLOB.deadmins) //austation -- restart votes doesn't ignore deadmins
 			if(!C.is_afk() && check_rights_for(C, R_SERVER))
 				active_admins = 1
 				break


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

makes restart votes not ignore deadmins and cancels them when they're on

## Why It's Good For The Game

Ided restart pls

## Changelog
:cl:
admin: restart votes doesn't ignore deadmins
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
