### PR TITLE
[PORT] Ports tail entwining from /tg/station

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -286,9 +286,18 @@
 
 		log_combat(src, M, "grabbed", addition="passive grab")
 		if(!supress_message && !(iscarbon(AM) && HAS_TRAIT(src, TRAIT_STRONG_GRABBER)))
-			M.visible_message("<span class='warning'>[src] grabs [M] [(zone_selected == "l_arm" || zone_selected == "r_arm")? "by their hands":"passively"]!</span>", \
-							"<span class='warning'>[src] grabs you [(zone_selected == "l_arm" || zone_selected == "r_arm")? "by your hands":"passively"]!</span>", null, null, src)
-			to_chat(src, "<span class='notice'>You grab [M] [(zone_selected == "l_arm" || zone_selected == "r_arm")? "by their hands":"passively"]!</span>")
+			if(zone_selected == BODY_ZONE_PRECISE_GROIN && istype(getorganslot(ORGAN_SLOT_TAIL), /obj/item/organ/tail)) // austation begin -- tail entwining, this time with catgirl/human ships in mind too
+				var/mob/living/L = M
+				if(istype(L) && istype(L.getorganslot(ORGAN_SLOT_TAIL), /obj/item/organ/tail)) // we both have tails
+					M.visible_message("<span class='warning'>[src] entwines their tail with [L]'s, wow is that okay in public?!</span>", "[src] entwines their tail with your own!", null, null, src)
+					to_chat(src, "You entwine your tail with [L]'s.")
+				else // only we have a tail
+					M.visible_message("<span class='warning'>[src] wraps their tail around [L]'s arm, wow is that okay in public?!</span>", "[src] wraps their tail around your arm!", null, null, src)
+					to_chat(src, "You wrap your tail around [L]'s arm.")
+			else
+				M.visible_message("<span class='warning'>[src] grabs [M] [(zone_selected == "l_arm" || zone_selected == "r_arm")? "by their hands":"passively"]!</span>", \
+								"<span class='warning'>[src] grabs you [(zone_selected == "l_arm" || zone_selected == "r_arm")? "by your hands":"passively"]!</span>", null, null, src)
+				to_chat(src, "<span class='notice'>You grab [M] [(zone_selected == "l_arm" || zone_selected == "r_arm")? "by their hands":"passively"]!</span>") // austation end
 		if(!iscarbon(src))
 			M.LAssailant = null
 		else


### PR DESCRIPTION
## About The Pull Request
Ports tgstation/tgstation#54991
Adds tail entwining ported from /tg/station. Very great feature, allows our catgirl ships to RP better.
Target groin and passive grab to use.

## Why It's Good For The Game
Why isn't it? It's a great feature and I improved it a lot compared to the original.

## Changelog
:cl:
add: Tail entwining for catgirls
/:cl: