### PR TITLE
Proper roundend discordmsg emptying

### DIFF
--- a/austation/code/_HELPERS/roundend.dm
+++ b/austation/code/_HELPERS/roundend.dm
@@ -22,12 +22,12 @@
 	else
 		discordmsg += "There were no antagonists!\n"
 	send2chat(discordmsg, "roundend")
-	discordmsg = ""
 	if(GLOB.antagonists.len)
 		for(var/datum/antagonist/A in GLOB.antagonists)
 			if(!A.owner)
 				continue
 
+			discordmsg = ""			
 			var/list/antag_info = list()
 			antag_info["key"] = A.owner.key
 			antag_info["name"] = A.owner.name


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This stops this:
![Screenshot 2020-11-28 202736](https://user-images.githubusercontent.com/8010007/100514501-a06a5a00-31b8-11eb-92b7-dfd3bde491a4.png)
_Fig 1. Pablo Huey appears twice_

Now one antag occupies one Discord message via proper use of `discordmsg = ""`

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This makes roundend Discord messages more readable.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed roundend Discord antag message spam
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
