### PR TITLE
Bluespace jars can now contain reagents 2: Electric boogaloo

### DIFF
--- a/austation/code/game/objects/items/bluespace_jar.dm
+++ b/austation/code/game/objects/items/bluespace_jar.dm
@@ -36,7 +36,6 @@
 	var/sipping_level = 150 //level until the reagent gets INGEST ed instead of TOUCH
 	var/sipping_probably = 99 //prob50 level of sipping
 	var/transfer_rate = 5 //chem transfer rate / second
-	var/spillable = TRUE
 
 /obj/item/bluespace_jar/Initialize()
 	. = ..()
@@ -78,10 +77,8 @@
 /obj/item/bluespace_jar/attack_self(mob/living/user)
 	if(reagents)
 		if(open)
-			spillable = FALSE
 			reagents.flags = NONE
 		else
-			spillable = TRUE
 			reagents.flags = OPENCONTAINER
 	if(open)
 		to_chat(user, "<span class='notice'>You close [src]'s [entrance_name].</span>")
@@ -243,7 +240,7 @@
 	if(occupants.len)
 		loc.visible_message("<span class='warning'>The bluespace jar smashes, releasing [occupants[1]]!</span>")
 
-	if(reagents?.total_volume && ismob(hit_atom) && hit_atom.reagents && (spillable == TRUE))
+	if(reagents?.total_volume && ismob(hit_atom) && hit_atom.reagents && open)
 		reagents.total_volume *= rand(5,10) * 0.1 //Not all of it makes contact with the target
 		var/mob/M = hit_atom
 		var/R = reagents.log_list()

--- a/austation/code/game/objects/items/bluespace_jar.dm
+++ b/austation/code/game/objects/items/bluespace_jar.dm
@@ -79,8 +79,10 @@
 	if(reagents)
 		if(open)
 			spillable = FALSE
+			reagents.flags = NONE
 		else
 			spillable = TRUE
+			reagents.flags = OPENCONTAINER
 	if(open)
 		to_chat(user, "<span class='notice'>You close [src]'s [entrance_name].</span>")
 		playsound(user, 'sound/effects/bin_close.ogg', 50, TRUE)

--- a/austation/code/game/objects/items/bluespace_jar.dm
+++ b/austation/code/game/objects/items/bluespace_jar.dm
@@ -258,12 +258,9 @@
 		hit_atom.visible_message("<span class='danger'>[M] has been splashed with something!</span>", \
 						"<span class='userdanger'>[M] has been splashed with something!</span>")
 		var/turf/TT = get_turf(hit_atom)
-		var/throwerstring
 		if(thrownby)
 			log_combat(thrownby, M, "splashed", R)
-			var/turf/AT = get_turf(thrownby)
-			throwerstring = " THROWN BY [key_name(thrownby)] at [AT] (AREACOORD(AT)]"
-		log_reagent("SPLASH: [src] mob throw_impact() onto [key_name(hit_atom)] at [TT] ([AREACOORD(TT)])[throwerstring] - [R]")
+			message_admins("[ADMIN_LOOKUPFLW(thrownby)] splashed (thrown) [english_list(reagents.reagent_list)] on [TT] at [ADMIN_VERBOSEJMP(TT)].")
 		reagents.reaction(hit_atom, TOUCH)
 		reagents.clear_reagents()
 

--- a/austation/code/game/objects/items/bluespace_jar.dm
+++ b/austation/code/game/objects/items/bluespace_jar.dm
@@ -46,14 +46,6 @@
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 
-/obj/item/bluespace_jar/attack_self(mob/living/user)
-	..()
-	if(reagents)
-		if(open)
-			spillable = FALSE
-		else
-			spillable = TRUE
-
 /obj/item/bluespace_jar/Destroy()
 	if(occupants.len)
 		for(var/V in occupants)
@@ -85,12 +77,13 @@
 		. += "<span class='notice'>Activate it in your hand to [open ? "close" : "open"] its [entrance_name].</span>"
 		if(!open)
 			. += "<span class='notice'>Alt-click to [locked ? "unlock" : "lock"] its [entrance_name].</span>"
-		if(!spillable)
-			. += "<span class='notice'>The cap is on to prevent spilling. Click to remove the cap.</span>"
-		else
-			. += "<span class='notice'>The cap has been taken off. Click to put a cap on.</span>"
 
 /obj/item/bluespace_jar/attack_self(mob/living/user)
+	if(reagents)
+		if(open)
+			spillable = FALSE
+		else
+			spillable = TRUE
 	if(open)
 		to_chat(user, "<span class='notice'>You close [src]'s [entrance_name].</span>")
 		playsound(user, 'sound/effects/bin_close.ogg', 50, TRUE)

--- a/austation/code/game/objects/items/bluespace_jar.dm
+++ b/austation/code/game/objects/items/bluespace_jar.dm
@@ -43,13 +43,10 @@
 	create_reagents(300, OPENCONTAINER) //equivalent of bsbeakers
 
 /obj/item/bluespace_jar/Destroy()
-	STOP_PROCESSING(SSobj, src)
-	return ..()
-
-/obj/item/bluespace_jar/Destroy()
 	if(occupants.len)
 		for(var/V in occupants)
 			remove_occupant(V)
+	STOP_PROCESSING(SSobj, src)
 	return ..()
 
 /obj/item/bluespace_jar/Exited(atom/movable/occupant)
@@ -265,6 +262,7 @@
 	if(!occupant_gas_supply)
 		occupant_gas_supply = new
 	if(ishuman(occupant)) //humans require resistance to cold/heat and living in no air while inside, and lose this when outside
+		START_PROCESSING(SSobj, src)
 		ADD_TRAIT(occupant, TRAIT_RESISTCOLD, "bluespace_container_cold_resist")
 		ADD_TRAIT(occupant, TRAIT_RESISTHEAT, "bluespace_container_heat_resist")
 		ADD_TRAIT(occupant, TRAIT_NOBREATH, "bluespace_container_no_breath")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports Citadel-Station-13/Citadel-Station-13#13143

## Why It's Good For The Game

NO NOT THE JAR

![image0](https://user-images.githubusercontent.com/56778689/100215752-8553dc00-2f65-11eb-974e-532cb3a9f8f7.png)
## Changelog
:cl: LetterN
tweak: bluespace jars can now contain reagents
/:cl:
![image1](https://user-images.githubusercontent.com/56778689/100215790-9270cb00-2f65-11eb-85f7-1aa646d653fc.png)

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
