### PR TITLE
Removes orphaned pipes

### DIFF
--- a/_maps/map_files/Austation/Austation.dmm
+++ b/_maps/map_files/Austation/Austation.dmm
@@ -54570,13 +54570,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
-"jzi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external,
-/turf/open/floor/plating,
-/area/science/shuttledock)
 "jzp" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -57476,13 +57469,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"kFX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/machinery/door/airlock/external,
-/turf/open/floor/plating,
-/area/science/shuttledock)
 "kGe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59544,13 +59530,6 @@
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
-"lEj" = (
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "lFt" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
@@ -105360,7 +105339,7 @@ yaE
 alC
 aqK
 aqO
-lEj
+alC
 aGN
 lPu
 bTp
@@ -130059,10 +130038,10 @@ mjJ
 dDB
 mjJ
 nfT
-jzi
+bcp
 pqW
 lsq
-jzi
+bcp
 gGe
 mjJ
 mjJ
@@ -130576,7 +130555,7 @@ btQ
 bcp
 nmh
 lsq
-kFX
+bcp
 nmh
 aaa
 lMJ


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This is essentially Beestation/Beestation-Hornet#3125 but on Austation map. The map didn't have any erroneous piping, it only had useless pipes that warranted removal: residual pipes at science shuttle airlocks and a random stray pipe at "south arrival maints".

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This is just cleanup, mostly. Nothing notable to see...

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: A few useless and stray pipes at Austation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
