### PR TITLE
Rebalances material availability in cargo

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -121,6 +121,9 @@ GLOBAL_LIST_INIT(diamond_recipes, list ( \
 	recipes = GLOB.diamond_recipes
 	. = ..()
 
+/obj/item/stack/sheet/mineral/diamond/twenty
+	amount = 20
+
 /*
  * Uranium
  */
@@ -146,6 +149,9 @@ GLOBAL_LIST_INIT(uranium_recipes, list ( \
 /obj/item/stack/sheet/mineral/uranium/Initialize(mapload, new_amount, merge = TRUE)
 	recipes = GLOB.uranium_recipes
 	. = ..()
+
+/obj/item/stack/sheet/mineral/uranium/fifty
+	amount = 50
 
 /*
  * Plasma
@@ -190,6 +196,9 @@ GLOBAL_LIST_INIT(plasma_recipes, list ( \
 	atmos_spawn_air("plasma=[amount*10];TEMP=[exposed_temperature]")
 	qdel(src)
 
+/obj/item/stack/sheet/mineral/plasma/fifty
+	amount = 50
+
 /*
  * Gold
  */
@@ -218,6 +227,9 @@ GLOBAL_LIST_INIT(gold_recipes, list ( \
 /obj/item/stack/sheet/mineral/gold/Initialize(mapload, new_amount, merge = TRUE)
 	recipes = GLOB.gold_recipes
 	. = ..()
+
+/obj/item/stack/sheet/mineral/gold/fifty
+	amount = 50
 
 /*
  * Silver
@@ -248,6 +260,9 @@ GLOBAL_LIST_INIT(silver_recipes, list ( \
 	recipes = GLOB.silver_recipes
 	. = ..()
 
+/obj/item/stack/sheet/mineral/silver/fifty
+	amount = 50
+
 /*
  * Copper
  */
@@ -271,6 +286,9 @@ GLOBAL_LIST_INIT(copper_recipes, list ( \
 /obj/item/stack/sheet/mineral/copper/Initialize(mapload, new_amount, merge = TRUE)
 	recipes = GLOB.copper_recipes
 	. = ..()
+
+/obj/item/stack/sheet/mineral/copper/fifty
+	amount = 50
 
 /*
  * Clown

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -11,7 +11,7 @@
 		. += " Thanks for participating in Nanotrasen Crates Recycling Program."
 
 /datum/export/large/crate/wooden
-	cost = 100
+	cost = 40	//austation change to fall in line with new material prices.  Old price 100
 	unit_name = "large wooden crate"
 	export_types = list(/obj/structure/closet/crate/large)
 	exclude_types = list()
@@ -21,13 +21,13 @@
 	export_types = list(/obj/structure/ore_box)
 
 /datum/export/large/crate/wood
-	cost = 240
+	cost = 50	//austation change to fall in line with new material prices.  Old price 250
 	unit_name = "wooden crate"
 	export_types = list(/obj/structure/closet/crate/wooden)
 	exclude_types = list()
 
-/datum/export/large/crate/coffin
-	cost = 250//50 wooden crates cost 2000 points, and you can make 10 coffins in seconds with those planks. Each coffin selling for 250 means you can make a net gain of 500 points for wasting your time making coffins.
+/datum/export/large/crate/coffin	//austation change to fall in line with new material prices.  Old price 250
+	cost = 50//50 wooden crates cost 850 points, and you can make 10 coffins in seconds with those planks. Each coffin selling for 50 means you can make a net gain of 250 points for wasting your time making coffins.
 	unit_name = "coffin"
 	export_types = list(/obj/structure/closet/crate/coffin)
 

--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -35,12 +35,12 @@
 	message = "cm3 of bananium"
 
 /datum/export/material/diamond
-	cost = 500
+	cost = 250	//austation change - halved export price.  Nobody sells diamonds and realistically 500 per sheet is just too much.  Lets me add diamond as an import without it costing 40K per crate.
 	material_id = /datum/material/diamond
 	message = "cm3 of diamonds"
 
 /datum/export/material/plasma
-	cost = 200
+	cost = 100
 	k_elasticity = 0
 	material_id = /datum/material/plasma
 	message = "cm3 of plasma"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1158,7 +1158,7 @@
 	name = "20 Diamond Sheets"
 	desc = "Shine on, these crazy diamonds."
 	cost = 7000
-	contains = list(/obj/item/stack/sheet/diamond/twenty)
+	contains = list(/obj/item/stack/sheet/mineral/diamond/twenty)
 	crate_name = "diamond sheets crate"
 
 /datum/supply_pack/materials/glass50
@@ -1168,7 +1168,7 @@
 	contains = list(/obj/item/stack/sheet/glass/fifty)
 	crate_name = "glass sheets crate"
 
-/datum/supply_pack/materials/gold20	//austation change,  new material crate: the standard price is 130% of the resale value, plus 500 for the crate and then rounded up
+/datum/supply_pack/materials/gold50	//austation change,  new material crate: the standard price is 130% of the resale value, plus 500 for the crate and then rounded up
 	name = "20 Gold Sheets"
 	desc = "Begin your long task to turn this station into the new El Dorado!"
 	cost = 4000
@@ -1186,7 +1186,7 @@
 	name = "50 Plasma Sheets"
 	desc = "I thought we sent YOU to mine this stuff?"
 	cost = 7000
-	contains = list(/obj/item/stack/sheet/plasma/fifty)
+	contains = list(/obj/item/stack/sheet/mineral/plasma/fifty)
 	crate_name = "plasma sheets crate"
 
 /datum/supply_pack/materials/plasteel20

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1143,56 +1143,105 @@
 /datum/supply_pack/materials/cardboard50
 	name = "50 Cardboard Sheets"
 	desc = "Create a bunch of boxes."
-	cost = 1000
+	cost = 600	//austation change. down from 1000 because you can't sell cardboard
 	contains = list(/obj/item/stack/sheet/cardboard/fifty)
 	crate_name = "cardboard sheets crate"
+
+/datum/supply_pack/materials/copper50	//austation change,  new material crate: the standard price is 130% of the resale value, plus 500 for the crate and then rounded up
+	name = "50 Copper Sheets"
+	desc = "Not at all a beloved furnishing in mafia hideouts."
+	cost = 1500
+	contains = list(/obj/item/stack/sheet/mineral/copper/fifty)
+	crate_name = "wood planks crate"
+
+/datum/supply_pack/materials/diamond20	//austation change,  new material crate: the standard price is 130% of the resale value, plus 500 for the crate and then rounded up
+	name = "20 Diamond Sheets"
+	desc = "Shine on, these crazy diamonds."
+	cost = 7000
+	contains = list(/obj/item/stack/sheet/diamond/twenty)
+	crate_name = "diamond sheets crate"
 
 /datum/supply_pack/materials/glass50
 	name = "50 Glass Sheets"
 	desc = "Let some nice light in with fifty glass sheets!"
-	cost = 1000
+	cost = 850	//austation change. down from 1000 to fall in line with other prices
 	contains = list(/obj/item/stack/sheet/glass/fifty)
 	crate_name = "glass sheets crate"
+
+/datum/supply_pack/materials/gold20	//austation change,  new material crate: the standard price is 130% of the resale value, plus 500 for the crate and then rounded up
+	name = "20 Gold Sheets"
+	desc = "Begin your long task to turn this station into the new El Dorado!"
+	cost = 4000
+	contains = list(/obj/item/stack/sheet/mineral/gold/fifty)
+	crate_name = "gold leaves crate"
 
 /datum/supply_pack/materials/iron50
 	name = "50 Iron Sheets"
 	desc = "Any construction project begins with a good stack of fifty iron sheets!"
-	cost = 1000
+	cost = 850	//austation change. down from 1000 to fall in line with other prices
 	contains = list(/obj/item/stack/sheet/iron/fifty)
 	crate_name = "iron sheets crate"
+
+/datum/supply_pack/materials/plasma50	//austation change,  new material crate: the standard price is 130% of the resale value, plus 500 for the crate and then rounded up
+	name = "50 Plasma Sheets"
+	desc = "I thought we sent YOU to mine this stuff?"
+	cost = 7000
+	contains = list(/obj/item/stack/sheet/plasma/fifty)
+	crate_name = "plasma sheets crate"
 
 /datum/supply_pack/materials/plasteel20
 	name = "20 Plasteel Sheets"
 	desc = "Reinforce the station's integrity with twenty plasteel sheets!"
-	cost = 7500
+	cost = 4500	//austation change, down from 7500 to fall in line with other prices
 	contains = list(/obj/item/stack/sheet/plasteel/twenty)
 	crate_name = "plasteel sheets crate"
 
 /datum/supply_pack/materials/plasteel50
 	name = "50 Plasteel Sheets"
 	desc = "For when you REALLY have to reinforce something."
-	cost = 16500
+	cost = 10500	//austation change, down from 16500 to fall in line with other prices
 	contains = list(/obj/item/stack/sheet/plasteel/fifty)
 	crate_name = "plasteel sheets crate"
 
 /datum/supply_pack/materials/plastic50
 	name = "50 Plastic Sheets"
 	desc = "Build a limitless amount of toys with fifty plastic sheets!"
-	cost = 1000
+	cost = 600	//austation change. down from 1000 because you can't sell plastic
 	contains = list(/obj/item/stack/sheet/plastic/fifty)
 	crate_name = "plastic sheets crate"
 
 /datum/supply_pack/materials/sandstone30
 	name = "30 Sandstone Blocks"
 	desc = "Neither sandy nor stoney, these thirty blocks will still get the job done."
-	cost = 1000
+	cost = 850	//austation change. down from 1000 because you can't sell sandstone
 	contains = list(/obj/item/stack/sheet/mineral/sandstone/thirty)
 	crate_name = "sandstone blocks crate"
+
+/datum/supply_pack/materials/silver20	//austation change,  new material crate: the standard price is 130% of the resale value, plus 500 for the crate and then rounded up
+	name = "20 Silver Sheets"
+	desc = "Furnish your station with tacky silver statues or do something useful with it."
+	cost = 3200
+	contains = list(/obj/item/stack/sheet/mineral/silver/fifty)
+	crate_name = "silver ingots crate"
+
+/datum/supply_pack/materials/titanium50	//austation change,  new material crate: the standard price is 130% of the resale value, plus 500 for the crate and then rounded up
+	name = "50 Titanium Sheets"
+	desc = "Almost, not quite the most expensive material crate on the list.  We checked twice."
+	cost = 8500
+	contains = list(/obj/item/stack/sheet/mineral/titanium/fifty)
+	crate_name = "titanium sheets crate"
+
+/datum/supply_pack/materials/uranium50	//austation change,  new material crate: the standard price is 130% of the resale value, plus 500 for the crate and then rounded up
+	name = "50 Uranium sheets"
+	desc = "Who knew it was this easy to order fissile material without a single permit check in place?"
+	cost = 7000
+	contains = list(/obj/item/stack/sheet/mineral/uranium/fifty)
+	crate_name = "uranium bars crate"
 
 /datum/supply_pack/materials/wood50
 	name = "50 Wood Planks"
 	desc = "Turn cargo's boring metal groundwork into beautiful panelled flooring and much more with fifty wooden planks!"
-	cost = 2000
+	cost = 850	//austation change. down from 1000 to fall in line with other prices.  prices of wooden crates has been reduced too
 	contains = list(/obj/item/stack/sheet/mineral/wood/fifty)
 	crate_name = "wood planks crate"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes materials more available in cargo for rounds where there are no miners.  A fast way to trade convenience for THOUSANDS of credits.
All pack (including previously existing packs) prices are balanced to be worth 30% more than the value you could make back by selling the materials and the crate they came in.
Wooden byproducts such as ore boxes and coffins can be sold to make back the value of the wood, plus 250c (down from around 500)
Diamonds have had their price halved because it was honestly insane and nobody sells diamond anyway.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This will help on the very rare occasions when miners have not joined (more important in lowpop seasons) and is a step in the direction needed before Lostman can even begin to consider removing the mining minigame.
IMPORTANT: This PR does not remove mining or affect the availability of mined materials, it only puts materials into cargo at exorbitant prices.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: copper to cargo
add: silver to cargo
add: plasma to cargo
add: titanium to cargo
add: gold to cargo
add: uranium to cargo
add: diamond to cargo
balance: repriced plasteel imports
balance: repriced wood byproduct imports
balance: repriced diamond exports
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
