### PR TITLE
new comms console param

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -753,6 +753,7 @@
 	message["message_sender"] = station_name()
 	message["message"] = msg
 	message["source"] = "([CONFIG_GET(string/cross_comms_name)])"
+	message["type"] = "Comms_Console" // small adaption to allow easier comms with goon server(s)
 	message += "Comms_Console"
 
 	var/comms_key = CONFIG_GET(string/comms_key)


### PR DESCRIPTION
adds a new type param to comms code, to make Topic() integration on our goon testing server easier.
shouldn't cause any incompatibilities with other servers.