### PR TITLE
Meathook stunlock rebalance

### DIFF
--- a/austation/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/austation/code/modules/mining/lavaland/necropolis_chests.dm
@@ -65,3 +65,7 @@ Beeloot is the number of items in Bees loot table excluding disabled loot
 /obj/item/tank/internals/occult/deconstruct(disassembled = TRUE)
   explosion(src, 0, 0, 8)
   ..()
+/obj/item/projectile/hook
+	damage = 50
+	armour_penetration = 100
+	damage_type = STAMINA

--- a/austation/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/austation/code/modules/mining/lavaland/necropolis_chests.dm
@@ -67,5 +67,4 @@ Beeloot is the number of items in Bees loot table excluding disabled loot
   ..()
 /obj/item/projectile/hook
 	damage = 50
-	armour_penetration = 100
 	damage_type = STAMINA


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Meathook nerf suggested by Alice, Kay and Nus.
Removes the hardstun applied by meathooks.
Does not affect the bounty hunter's meathook (which is weaker)
Meathook already ignores all armor, so unless I'm told to change this, it still will and you'll consistently get hit with the full 50 stam damage.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
less stunlocking
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: meathooks no longer deal 25 brute
balance: meathooks no longer paralyze for 3 seconds
balance: meathooks now apply 50 stamina damage (ignores armor)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
