### PR TITLE
Remove Head/AI job selection bias at roundstart

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -191,8 +191,8 @@ SUBSYSTEM_DEF(job)
 //This proc is called before the level loop of DivideOccupations() and will try to select a head, ignoring ALL non-head preferences for every level until
 //it locates a head or runs out of levels to check
 //This is basically to ensure that there's atleast a few heads in the round
-/* This is a certified AUStation coding moment, by Mudzbe. The Head and AI selection process gives the opposite of intended results, encouraging players to
-not put down AI/head in their preferences for fear of being guaranteed those positions, this is true for AUStation at least.
+/* Austation, PR: #3030 -- The Head and AI selection process gives the opposite of intended results, encouraging players to
+not put down AI/head in their preferences, for fear of being guaranteed those positions, this is true for AUStation at least.
 /datum/controller/subsystem/job/proc/FillHeadPosition()
 	for(var/level in level_order)
 		for(var/command_position in GLOB.command_positions)
@@ -244,7 +244,7 @@ not put down AI/head in their preferences for fear of being guaranteed those pos
 	if(ai_selected)
 		return 1
 	return 0
-*/
+AUStation end */
 
 /** Proc DivideOccupations
  *  fills var "assigned_role" for all ready players.

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -191,56 +191,60 @@ SUBSYSTEM_DEF(job)
 //This proc is called before the level loop of DivideOccupations() and will try to select a head, ignoring ALL non-head preferences for every level until
 //it locates a head or runs out of levels to check
 //This is basically to ensure that there's atleast a few heads in the round
-//datum/controller/subsystem/job/proc/FillHeadPosition()
-//	for(var/level in level_order)
-//		for(var/command_position in GLOB.command_positions)
-//			var/datum/job/job = GetJob(command_position)
-//			if(!job)
-//				continue
-//			if((job.current_positions >= job.total_positions) && job.total_positions != -1)
-//				continue
-//			var/list/candidates = FindOccupationCandidates(job, level)
-//			if(!candidates.len)
-//				continue
-//			var/mob/dead/new_player/candidate = pick(candidates)
-//			if(AssignRole(candidate, command_position))
-//				return 1
-//	return 0
+/* This is a certified AUStation coding moment, by Mudzbe. The Head and AI selection process gives the opposite of intended results, encouraging players to
+not put down AI/head in their preferences for fear of being guaranteed those positions, this is true for AUStation at least.
+/datum/controller/subsystem/job/proc/FillHeadPosition()
+	for(var/level in level_order)
+		for(var/command_position in GLOB.command_positions)
+			var/datum/job/job = GetJob(command_position)
+			if(!job)
+				continue
+			if((job.current_positions >= job.total_positions) && job.total_positions != -1)
+				continue
+			var/list/candidates = FindOccupationCandidates(job, level)
+			if(!candidates.len)
+				continue
+			var/mob/dead/new_player/candidate = pick(candidates)
+			if(AssignRole(candidate, command_position))
+				return 1
+	return 0
+
 
 
 //This proc is called at the start of the level loop of DivideOccupations() and will cause head jobs to be checked before any other jobs of the same level
 //This is also to ensure we get as many heads as possible
-//datum/controller/subsystem/job/proc/CheckHeadPositions(level)
-//	for(var/command_position in GLOB.command_positions)
-//		var/datum/job/job = GetJob(command_position)
-//		if(!job)
-//			continue
-//		if((job.current_positions >= job.total_positions) && job.total_positions != -1)
-//			continue
-//		var/list/candidates = FindOccupationCandidates(job, level)
-//		if(!candidates.len)
-//			continue
-//		var/mob/dead/new_player/candidate = pick(candidates)
-//		AssignRole(candidate, command_position)
 
-//datum/controller/subsystem/job/proc/FillAIPosition()
-	//var/ai_selected = 0
-	//var/datum/job/job = GetJob("AI")
-	//if(!job)
-	//	return 0
-	//for(var/i = job.total_positions, i > 0, i--)
-	//	for(var/level in level_order)
-	//		var/list/candidates = list()
-	//		candidates = FindOccupationCandidates(job, level)
-	//		if(candidates.len)
-	//			var/mob/dead/new_player/candidate = pick(candidates)
-	//			if(AssignRole(candidate, "AI"))
-	//				ai_selected++
-	//				break
-	//if(ai_selected)
-	//	return 1
-	//return 0
+/datum/controller/subsystem/job/proc/CheckHeadPositions(level)
+	for(var/command_position in GLOB.command_positions)
+		var/datum/job/job = GetJob(command_position)
+		if(!job)
+			continue
+		if((job.current_positions >= job.total_positions) && job.total_positions != -1)
+			continue
+		var/list/candidates = FindOccupationCandidates(job, level)
+		if(!candidates.len)
+			continue
+		var/mob/dead/new_player/candidate = pick(candidates)
+		AssignRole(candidate, command_position)
 
+/datum/controller/subsystem/job/proc/FillAIPosition()
+	var/ai_selected = 0
+	var/datum/job/job = GetJob("AI")
+	if(!job)
+		return 0
+	for(var/i = job.total_positions, i > 0, i--)
+		for(var/level in level_order)
+			var/list/candidates = list()
+			candidates = FindOccupationCandidates(job, level)
+			if(candidates.len)
+				var/mob/dead/new_player/candidate = pick(candidates)
+				if(AssignRole(candidate, "AI"))
+					ai_selected++
+					break
+	if(ai_selected)
+		return 1
+	return 0
+*/
 
 /** Proc DivideOccupations
  *  fills var "assigned_role" for all ready players.

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -191,55 +191,55 @@ SUBSYSTEM_DEF(job)
 //This proc is called before the level loop of DivideOccupations() and will try to select a head, ignoring ALL non-head preferences for every level until
 //it locates a head or runs out of levels to check
 //This is basically to ensure that there's atleast a few heads in the round
-/datum/controller/subsystem/job/proc/FillHeadPosition()
-	for(var/level in level_order)
-		for(var/command_position in GLOB.command_positions)
-			var/datum/job/job = GetJob(command_position)
-			if(!job)
-				continue
-			if((job.current_positions >= job.total_positions) && job.total_positions != -1)
-				continue
-			var/list/candidates = FindOccupationCandidates(job, level)
-			if(!candidates.len)
-				continue
-			var/mob/dead/new_player/candidate = pick(candidates)
-			if(AssignRole(candidate, command_position))
-				return 1
-	return 0
+//datum/controller/subsystem/job/proc/FillHeadPosition()
+//	for(var/level in level_order)
+//		for(var/command_position in GLOB.command_positions)
+//			var/datum/job/job = GetJob(command_position)
+//			if(!job)
+//				continue
+//			if((job.current_positions >= job.total_positions) && job.total_positions != -1)
+//				continue
+//			var/list/candidates = FindOccupationCandidates(job, level)
+//			if(!candidates.len)
+//				continue
+//			var/mob/dead/new_player/candidate = pick(candidates)
+//			if(AssignRole(candidate, command_position))
+//				return 1
+//	return 0
 
 
 //This proc is called at the start of the level loop of DivideOccupations() and will cause head jobs to be checked before any other jobs of the same level
 //This is also to ensure we get as many heads as possible
-/datum/controller/subsystem/job/proc/CheckHeadPositions(level)
-	for(var/command_position in GLOB.command_positions)
-		var/datum/job/job = GetJob(command_position)
-		if(!job)
-			continue
-		if((job.current_positions >= job.total_positions) && job.total_positions != -1)
-			continue
-		var/list/candidates = FindOccupationCandidates(job, level)
-		if(!candidates.len)
-			continue
-		var/mob/dead/new_player/candidate = pick(candidates)
-		AssignRole(candidate, command_position)
+//datum/controller/subsystem/job/proc/CheckHeadPositions(level)
+//	for(var/command_position in GLOB.command_positions)
+//		var/datum/job/job = GetJob(command_position)
+//		if(!job)
+//			continue
+//		if((job.current_positions >= job.total_positions) && job.total_positions != -1)
+//			continue
+//		var/list/candidates = FindOccupationCandidates(job, level)
+//		if(!candidates.len)
+//			continue
+//		var/mob/dead/new_player/candidate = pick(candidates)
+//		AssignRole(candidate, command_position)
 
-/datum/controller/subsystem/job/proc/FillAIPosition()
-	var/ai_selected = 0
-	var/datum/job/job = GetJob("AI")
-	if(!job)
-		return 0
-	for(var/i = job.total_positions, i > 0, i--)
-		for(var/level in level_order)
-			var/list/candidates = list()
-			candidates = FindOccupationCandidates(job, level)
-			if(candidates.len)
-				var/mob/dead/new_player/candidate = pick(candidates)
-				if(AssignRole(candidate, "AI"))
-					ai_selected++
-					break
-	if(ai_selected)
-		return 1
-	return 0
+//datum/controller/subsystem/job/proc/FillAIPosition()
+	//var/ai_selected = 0
+	//var/datum/job/job = GetJob("AI")
+	//if(!job)
+	//	return 0
+	//for(var/i = job.total_positions, i > 0, i--)
+	//	for(var/level in level_order)
+	//		var/list/candidates = list()
+	//		candidates = FindOccupationCandidates(job, level)
+	//		if(candidates.len)
+	//			var/mob/dead/new_player/candidate = pick(candidates)
+	//			if(AssignRole(candidate, "AI"))
+	//				ai_selected++
+	//				break
+	//if(ai_selected)
+	//	return 1
+	//return 0
 
 
 /** Proc DivideOccupations
@@ -298,17 +298,17 @@ SUBSYSTEM_DEF(job)
 	AustationFillBannedPosition() // austation -- ports catbans
 
 	//Select one head
-	JobDebug("DO, Running Head Check")
-	FillHeadPosition()
-	JobDebug("DO, Head Check end")
+	//JobDebug("DO, Running Head Check")
+	//FillHeadPosition()
+	//JobDebug("DO, Head Check end")
 
 	//Check for an AI
-	JobDebug("DO, Running AI Check")
-	FillAIPosition()
-	JobDebug("DO, AI Check end")
+	//JobDebug("DO, Running AI Check")
+	//FillAIPosition()
+	//JobDebug("DO, AI Check end")
 
 	//Other jobs are now checked
-	JobDebug("DO, Running Standard Check")
+	//JobDebug("DO, Running Standard Check")
 
 
 	// New job giving system by Donkie
@@ -319,7 +319,7 @@ SUBSYSTEM_DEF(job)
 	var/list/shuffledoccupations = shuffle(occupations)
 	for(var/level in level_order)
 		//Check the head jobs first each level
-		CheckHeadPositions(level)
+		//CheckHeadPositions(level)
 
 		// Loop through all unassigned players
 		for(var/mob/dead/new_player/player in unassigned)

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -244,7 +244,7 @@ not put down AI/head in their preferences, for fear of being guaranteed those po
 	if(ai_selected)
 		return 1
 	return 0
-AUStation end */
+*/
 
 /** Proc DivideOccupations
  *  fills var "assigned_role" for all ready players.
@@ -323,7 +323,7 @@ AUStation end */
 	var/list/shuffledoccupations = shuffle(occupations)
 	for(var/level in level_order)
 		//Check the head jobs first each level
-		//CheckHeadPositions(level)
+		//CheckHeadPositions(level) -- Austation job selection change end
 
 		// Loop through all unassigned players
 		for(var/mob/dead/new_player/player in unassigned)


### PR DESCRIPTION
## About The Pull Request

At the start of the round, there is a bias to select AIs and Heads over other jobs. The intended effect was to have more heads and AIs in round. However, on a server with lowpop like us, this has an opposite effect. If you set AI or a head role to low you are basically guaranteed to get that job. The players recognize this and don't set their preferences to Head or AI at all, in effect lowering the likelihood of getting a Head or AI on station. This PR removes that bias to select heads/AI at roundstart, so players can set these jobs to low or medium without the guarantee of getting them 100% of the time, they will be selected on a random basis rather than to fill the Head/AI quota.

I know this is good for AIs, but if there is not the same consensus for Head selection, I can alter it. Also, I commented out the selection code instead of deleting cuz idk

## Why It's Good For The Game

AI mains can set AI to low/med and not be guaranteed a round as AI, though they still can do that if they want, by putting it to high as opposed to everything else. It is the same situation for Heads.

## Changelog
:cl:
tweak: Removed Head/AI job selection bias in the roundstart job selection process. Review your preferences.
/:cl: