### PR TITLE
Overdose and Addiction Are Triggered When Reagents Are ABOVE Threshold

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -350,7 +350,7 @@
 					R.on_mob_metabolize(C)
 				if(can_overdose)
 					if(R.overdose_threshold)
-						if(R.volume > R.overdose_threshold && !R.overdosed)
+						if(R.volume > R.overdose_threshold && !R.overdosed) //This is a certified AUStation code moment, PR: #3045. Changed from >= to >
 							R.overdosed = 1
 							need_mob_update += R.overdose_start(C)
 					if(R.addiction_threshold)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -350,7 +350,7 @@
 					R.on_mob_metabolize(C)
 				if(can_overdose)
 					if(R.overdose_threshold)
-						if(R.volume > R.overdose_threshold && !R.overdosed) //This is a certified AUStation code moment, PR: #3045. Changed from >= to >
+						if(R.volume > R.overdose_threshold && !R.overdosed) //AUStation, PR: #3045 -- Changed from >= to >
 							R.overdosed = 1
 							need_mob_update += R.overdose_start(C)
 					if(R.addiction_threshold)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -350,11 +350,11 @@
 					R.on_mob_metabolize(C)
 				if(can_overdose)
 					if(R.overdose_threshold)
-						if(R.volume > R.overdose_threshold && !R.overdosed) //AUStation, PR: #3045 -- Changed from >= to >
+						if(R.volume > R.overdose_threshold && !R.overdosed) // austation -- PR: #3045 Changed from >= to >
 							R.overdosed = 1
 							need_mob_update += R.overdose_start(C)
 					if(R.addiction_threshold)
-						if(R.volume > R.addiction_threshold && !is_type_in_list(R, cached_addictions))
+						if(R.volume > R.addiction_threshold && !is_type_in_list(R, cached_addictions)) // austation -- PR: #3045 Changed from >= to >
 							var/datum/reagent/new_reagent = new R.type()
 							cached_addictions.Add(new_reagent)
 					if(R.overdosed)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -350,11 +350,11 @@
 					R.on_mob_metabolize(C)
 				if(can_overdose)
 					if(R.overdose_threshold)
-						if(R.volume >= R.overdose_threshold && !R.overdosed)
+						if(R.volume > R.overdose_threshold && !R.overdosed)
 							R.overdosed = 1
 							need_mob_update += R.overdose_start(C)
 					if(R.addiction_threshold)
-						if(R.volume >= R.addiction_threshold && !is_type_in_list(R, cached_addictions))
+						if(R.volume > R.addiction_threshold && !is_type_in_list(R, cached_addictions))
 							var/datum/reagent/new_reagent = new R.type()
 							cached_addictions.Add(new_reagent)
 					if(R.overdosed)


### PR DESCRIPTION
## About The Pull Request

This PR changes both addiction and overdose to only trigger when reagents are **above** their respective thresholds, as opposed to **above and equal** to the threshold. 
This means that if the threshold is 30u, having 30u in your bloodstream will not trigger either effect, whereas 30.1 units will. Before this was the opposite: Having 30u in the bloodstream WOULD trigger the effects, but 29.9 wouldn't.  

## Why It's Good For The Game

It makes chems less annoying, the previous system is stupid and I hate it. You can now have 0.1 more chems without experiencing addiction or overdose.

## Changelog
:cl:
tweak: Overdose and addiction are triggered when reagents are ABOVE threshold as opposed to ABOVE AND EQUAL to the threshold
/:cl:

