### PR TITLE
bees now die when stinging a living target

### DIFF
--- a/austation.dme
+++ b/austation.dme
@@ -177,6 +177,7 @@
 #include "austation\code\modules\mob\living\simple_animal\friendly\drone\emote.dm"
 #include "austation\code\modules\mob\living\simple_animal\friendly\drone\say.dm"
 #include "austation\code\modules\mob\living\simple_animal\friendly\drone\visuals_icons.dm"
+#include "austation\code\modules\mob\living\simple_animal\hostile\bees.dm"
 #include "austation\code\modules\mob\living\simple_animal\hostile\generic.dm"
 #include "austation\code\modules\mob\living\simple_animal\hostile\regalrat.dm"
 #include "austation\code\modules\mob\living\simple_animal\hostile\retaliate\kangaroo.dm"

--- a/austation/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/austation/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -1,4 +1,4 @@
 /mob/living/simple_animal/hostile/poison/bees/AttackingTarget()
 	..()
-	if isliving(target)
+	if (isliving(target))
 		Destroy()  //  please die, little bee

--- a/austation/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/austation/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -1,0 +1,4 @@
+/mob/living/simple_animal/hostile/poison/bees/AttackingTarget()
+	..()
+	if isliving(target)
+		Destroy()  //  please die, little bee


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Bees now die after stinging a living target, to fall in line more with reality, and to reduce the lethality of what should not be quite so lethal a throwaway mob.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ided
Also, this is an improvement to "positive" bees, who would otherwise just OD their targets, which completely defeats the point of making bees to be helpful.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: bees die after stinging a living target
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
