### PR TITLE
adds missing return to plating.dm

### DIFF
--- a/code/game/turfs/open/floor/plating.dm
+++ b/code/game/turfs/open/floor/plating.dm
@@ -105,6 +105,7 @@
 						PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 					else
 						to_chat(user, "<span class='warning'>You need to dig below the foundations first!</span>")
+						W.amount += 1
 						return
 			else
 				to_chat(user, "<span class='warning'>You can't place glass tiles over the platings!</span>")  //  austation end #2156

--- a/code/game/turfs/open/floor/plating.dm
+++ b/code/game/turfs/open/floor/plating.dm
@@ -105,6 +105,7 @@
 						PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 					else
 						to_chat(user, "<span class='warning'>You need to dig below the foundations first!</span>")
+						return
 			else
 				to_chat(user, "<span class='warning'>You can't place glass tiles over the platings!</span>")  //  austation end #2156
 			playsound(src, 'sound/weapons/genhit.ogg', 50, 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
using floor tiles on asteroid turf was warning you that you needed to dig below the foundations first, but still took your tile.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: applying plating to an undug asteroid floor now refunds your tile
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
