### PR TITLE
Adds Missing stamina armour flags

### DIFF
--- a/austation/code/modules/clothing/head/helmet.dm
+++ b/austation/code/modules/clothing/head/helmet.dm
@@ -4,5 +4,5 @@
   alternate_worn_icon = 'austation/icons/mob/head.dmi'
   icon = 'austation/icons/obj/clothing/hats.dmi'
   resistance_flags = FLAMMABLE
-  armor = list("melee" = 20, "bullet" = 10, "laser" = 30, "energy" = 40, "bomb" = 15, "bio" = 0, "rad" = 0, "fire" = 40, "acid" = 50)
+  armor = list("melee" = 20, "bullet" = 10, "laser" = 30, "energy" = 40, "bomb" = 15, "bio" = 0, "rad" = 0, "fire" = 40, "acid" = 50, "stamina" = 30)
   strip_delay = 60

--- a/austation/code/modules/clothing/masks/miscellaneous.dm
+++ b/austation/code/modules/clothing/masks/miscellaneous.dm
@@ -2,4 +2,4 @@
   name = "durathread bandana"
   desc =  "A bandana made from durathread."
   icon_state = "banddurathread"
-  armor = list("melee" = 10, "bullet" = 5, "laser" = 10,"energy" = 10, "bomb" = 5, "bio" = 0, "rad" = 0, "fire" = 40, "acid" = 10)
+  armor = list("melee" = 10, "bullet" = 5, "laser" = 10,"energy" = 10, "bomb" = 5, "bio" = 0, "rad" = 0, "fire" = 40, "acid" = 10, "stamina" = 10)

--- a/austation/code/modules/clothing/under/miscellaneous.dm
+++ b/austation/code/modules/clothing/under/miscellaneous.dm
@@ -43,7 +43,7 @@
 	item_state = "bl_suit"
 	item_color = "syndicate_skirt"
 	has_sensor = NO_SENSORS
-	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 40)
+	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 40, "stamina" = 30)
 	alt_covers_chest = TRUE
 	fitted = FEMALE_UNIFORM_TOP
 
@@ -55,7 +55,7 @@
 	icon_state = "tactifool_skirt"
 	item_state = "bl_suit"
 	item_color = "tactifool_skirt"
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 40)
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 40, "stamina" = 0)
 	fitted = FEMALE_UNIFORM_TOP
 
 /obj/item/clothing/under/misc/durathread
@@ -66,7 +66,7 @@
 	item_color = "durathread"
 	alternate_worn_icon = 'austation/icons/mob/uniform.dmi'
 	can_adjust = TRUE
-	armor = list("melee" = 10, "bullet" = 5, "laser" = 10,"energy" = 10, "bomb" = 5, "bio" = 0, "rad" = 0, "fire" = 40, "acid" = 10)
+	armor = list("melee" = 10, "bullet" = 5, "laser" = 10,"energy" = 10, "bomb" = 5, "bio" = 0, "rad" = 0, "fire" = 40, "acid" = 10, "stamina" = 30)
 
 /obj/item/clothing/under/misc/black_dress
 	name = "little black dress"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds stamina armour flags to Austation clothes. Most values are from Bee code, but Durathread bandana was given 10 stamina armour.

## Why It's Good For The Game

Stamina armour was added and these had not been changed

## Changelog
:cl:
tweak: adds missing stamina armour to austation clothes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
