### PR TITLE
Fixes a few issues with the cargo RBMK / AGCNR

### DIFF
--- a/austation/code/modules/power/reactor/reactor_cargo.dm
+++ b/austation/code/modules/power/reactor/reactor_cargo.dm
@@ -9,14 +9,16 @@
 	if(istype(I))
 		to_chat(user, "<span class='notice'>You add the reactor's ID to \the [src]>")
 		src.id = I.buffer
+		link_to_reactor()
 		return TRUE
 
 /obj/machinery/atmospherics/components/trinary/nuclear_reactor/cargo // easier on the brain
 
 /obj/machinery/atmospherics/components/trinary/nuclear_reactor/cargo/New()
+	. = ..()
 	id = rand(1, 1000000) // cmon, what are the chances?
 
-// Cargo varients can be wrenched down and don't start linked to the default RMBK reactor
+// Cargo variants can be wrenched down and don't start linked to the default RMBK reactor
 
 /obj/machinery/computer/reactor/control_rods/cargo
 	anchored = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so giving a computer a cargo reactor's ID through the multitool action forces it to call the link_to_reactor proc

Adds a supercall to the cargo nuclear reactor, allowing it to have a pipenet instead of crashing itself due to the lack thereof whenever it spawns.

## Why It's Good For The Game

Just a few issues I've noticed when I ported the cargo update to our downstream, this should help. Recently noticed this in a round where people tried to run 4 AGCNRs at once.

## Changelog
:cl:
fix: Cargo reactor not functioning
fix: Cargo reactor computers not linking to their respective reactors after being multitooled
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
