### PR TITLE
Restore Orbitalstation to working order: Part 1

### DIFF
--- a/_maps/map_files/OrbitalStation/OrbitalStation.dmm
+++ b/_maps/map_files/OrbitalStation/OrbitalStation.dmm
@@ -88,7 +88,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "acV" = (
 /obj/effect/turf_decal/tile/blue,
@@ -118,12 +118,20 @@
 	dir = 8
 	},
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "aeq" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"aeZ" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel/dark,
+/area/quartermaster/miningdock)
 "afd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -178,6 +186,12 @@
 	name = "Dorm 3"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
 /turf/open/floor/wood/airless,
 /area/crew_quarters/dorms)
 "agd" = (
@@ -214,6 +228,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"agX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/closed/wall,
+/area/ruin/space/derelict/hallway)
 "ahL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow,
@@ -304,6 +324,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/sign/poster/official/no_erp{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/crew_quarters/dorms)
 "akI" = (
@@ -311,6 +334,21 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/engine/gravity_generator)
+"alC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/crew_quarters/heads/captain/private{
+	name = "Admiral's Quarters"
+	})
 "alH" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -338,7 +376,7 @@
 /area/ruin/space/derelict/singularity_engine)
 "amL" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/crew_quarters/dorms)
 "anE" = (
@@ -346,6 +384,10 @@
 /obj/item/paper/fluff/holodeck/disclaimer,
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/crew_quarters/fitness)
 "aqD" = (
@@ -406,6 +448,12 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/bridge)
@@ -494,6 +542,19 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/bridge/access)
+"ayK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/plasteel/showroomfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/crew_quarters/cryopods)
 "ayL" = (
 /obj/item/bedsheet,
 /obj/structure/bed,
@@ -517,6 +578,20 @@
 /obj/machinery/portable_atmospherics/canister/bz,
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/storage/equipment)
+"ayY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/maintenance/department/eva)
 "azg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor/border_only,
@@ -548,6 +623,11 @@
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/quartermaster/storage)
+"azK" = (
+/turf/open/floor/plating/airless{
+	icon_state = "panelscorched"
+	},
+/area/space/nearstation)
 "aAh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -701,11 +781,14 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/derelict/storage/equipment)
 "aDH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
 "aEb" = (
@@ -716,6 +799,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/hallway/secondary/command)
@@ -730,8 +819,20 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/west{
+	start_charge = 0
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/derelict/hallway)
+"aES" = (
+/obj/machinery/atmospherics/components/binary/pump/on/layer3{
+	dir = 1
+	},
+/turf/closed/wall/r_wall,
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "aEX" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -805,7 +906,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/ruin/space/derelict/hallway)
 "aHP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -862,7 +963,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "aIe" = (
 /obj/effect/turf_decal/stripes/line{
@@ -942,17 +1043,11 @@
 /turf/open/floor/plating/airless,
 /area/medical/chemistry)
 "aLw" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
-/area/science/research/abandoned)
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "aMa" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -971,17 +1066,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
-"aMC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/space/derelict/hallway)
 "aMP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/robot_debris/old,
@@ -1015,6 +1099,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/exit)
+"aNC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
@@ -1072,7 +1163,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
 "aNZ" = (
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "panelscorched"
 	},
 /area/science/research/abandoned)
@@ -1116,6 +1207,12 @@
 	name = "Dorm 4"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
 /turf/open/floor/wood/airless,
 /area/crew_quarters/dorms)
 "aPY" = (
@@ -1212,21 +1309,27 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/derelict/hallway)
+/area/ruin/space/derelict/atmospherics)
 "aSL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/sign/warning/securearea{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume,
+/turf/open/floor/plating,
 /area/ruin/space/derelict/hallway)
+"aSQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/closed/wall,
+/area/medical/chemistry)
 "aSZ" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1267,13 +1370,6 @@
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/arrival)
-"aUA" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/supermatter)
 "aUE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -1346,7 +1442,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/mineral/plastitanium/airless,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "aWt" = (
 /obj/machinery/telecomms/processor/preset_three,
@@ -1360,6 +1456,15 @@
 	},
 /turf/open/space,
 /area/space)
+"aWZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/dark/airless,
+/area/crew_quarters/fitness)
 "aXf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -1410,6 +1515,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/engine/supermatter)
+"aZr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/plasteel/dark/airless,
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "aZB" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -1556,6 +1666,7 @@
 /area/tcommsat/server)
 "bdb" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/ai_monitored/storage/eva)
 "bex" = (
@@ -1597,11 +1708,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume,
+/obj/structure/sign/warning/securearea{
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
 /area/ruin/space/derelict/hallway)
 "bfs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1714,8 +1828,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/ai_monitored/security/armory)
@@ -1784,6 +1901,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
+"bko" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/obj/item/twohanded/required/kirbyplants/dead{
+	desc = "A dead plant.";
+	name = "dead plant";
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "bkL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -1795,6 +1923,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark/airless,
 /area/crew_quarters/dorms)
 "bkR" = (
@@ -1822,7 +1952,9 @@
 	name = "emergency shower"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/showroomfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/crew_quarters/cryopods)
 "blc" = (
 /obj/machinery/door/airlock{
@@ -1830,6 +1962,12 @@
 	name = "Dorm 2"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
 /turf/open/floor/wood/airless,
 /area/crew_quarters/dorms)
 "bmt" = (
@@ -1905,7 +2043,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/showroomfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/crew_quarters/cryopods)
 "bnZ" = (
 /obj/effect/turf_decal/loading_area{
@@ -2053,13 +2193,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
+"brV" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/turf/closed/wall,
+/area/hydroponics/garden/abandoned)
 "bsz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "bsN" = (
-/turf/open/floor/plating,
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "bsP" = (
 /obj/structure/table,
@@ -2090,6 +2235,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark/airless,
 /area/ai_monitored/turret_protected/ai)
+"btA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "btB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/loading_area{
@@ -2142,6 +2293,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "bvn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "bvu" = (
@@ -2185,10 +2337,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
 "bxs" = (
@@ -2302,6 +2454,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/bridge)
 "bCU" = (
@@ -2315,6 +2473,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
+"bDc" = (
+/obj/item/beacon,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/science/test_area)
 "bDj" = (
 /obj/machinery/door/firedoor/border_only/closed,
 /obj/machinery/door/firedoor/border_only/closed{
@@ -2410,20 +2575,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
+"bHM" = (
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "bHY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/space/derelict/hallway)
+/turf/open/space/basic,
+/area/crew_quarters/theatre)
 "bIa" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -2442,6 +2600,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/bridge)
 "bJi" = (
@@ -2478,6 +2638,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
 "bKg" = (
@@ -2527,6 +2689,9 @@
 	},
 /obj/structure/sign/poster/random{
 	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
@@ -2743,15 +2908,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark/airless,
 /area/medical/abandoned)
+"bUF" = (
+/obj/structure/sign/directions/engineering{
+	dir = 8;
+	pixel_y = 8
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/department/eva)
 "bUZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/terminal,
 /obj/structure/cable/yellow,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/derelict/hallway)
+/area/ruin/space/derelict/atmospherics)
 "bWN" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
@@ -2828,7 +2997,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -2944,7 +3113,9 @@
 /area/tcommsat/server)
 "ccu" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/showroomfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/crew_quarters/cryopods)
 "ccW" = (
 /obj/effect/turf_decal/tile/blue{
@@ -2960,15 +3131,19 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "cdf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plating,
 /area/crew_quarters/theatre)
+"cdr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume,
+/turf/open/floor/plating,
+/area/hydroponics/garden/abandoned)
 "cef" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -2986,6 +3161,19 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
+"ceh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/eastright{
+	base_state = "left";
+	dir = 1;
+	icon_state = "left";
+	name = "Chemistry Lab";
+	req_access_txt = "33"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel/dark/airless,
+/area/medical/chemistry)
 "cek" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -3058,6 +3246,20 @@
 "chf" = (
 /turf/closed/wall,
 /area/space)
+"chh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced,
+/obj/machinery/button/massdriver{
+	dir = 4;
+	id = "toxinsdriver";
+	pixel_x = 28
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/science/research/abandoned)
 "chi" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Virology Containment Cell";
@@ -3073,6 +3275,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "chj" = (
@@ -3160,16 +3365,21 @@
 	dir = 4;
 	pixel_y = -5
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless,
+/area/ruin/space/derelict/storage/equipment)
+"cjb" = (
+/obj/structure/girder,
+/turf/open/floor/plating/airless{
 	icon_state = "platingdmg3"
 	},
-/area/ruin/space/derelict/storage/equipment)
+/area/science/test_area)
 "cjh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/mime,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "cjs" = (
@@ -3204,6 +3414,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"ckm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/turf/open/floor/plasteel/dark/airless,
+/area/maintenance/department/eva)
 "ckq" = (
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg3"
@@ -3239,6 +3455,9 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/medical/chemistry)
@@ -3324,6 +3543,11 @@
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/engine/supermatter)
+"com" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden/abandoned)
 "coY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/circuitboard/computer/operating,
@@ -3442,10 +3666,10 @@
 "csl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/frame/computer,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark/airless,
@@ -3485,6 +3709,12 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room/council)
@@ -3628,7 +3858,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "cxU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3677,7 +3907,7 @@
 	},
 /obj/machinery/light/broken,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/mineral/plastitanium/airless,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "cyO" = (
 /turf/closed/wall,
@@ -3699,7 +3929,7 @@
 /area/ai_monitored/nuke_storage)
 "cze" = (
 /obj/structure/girder,
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "panelscorched"
 	},
 /area/engine/gravity_generator)
@@ -3727,9 +3957,9 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room/council)
 "czY" = (
-/turf/open/floor/plating/airless{
-	icon_state = "platingdmg1"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel/dark/airless,
 /area/bridge/showroom/corporate)
 "cAm" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -3753,11 +3983,28 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
+"cAB" = (
+/obj/machinery/door/window/northright,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden/abandoned)
 "cAG" = (
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/derelictoutpost/cargobay)
@@ -3786,6 +4033,12 @@
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/crew_quarters/fitness)
@@ -3824,8 +4077,18 @@
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/bridge)
 "cCi" = (
-/turf/open/floor/plating,
-/area/quartermaster/storage)
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/official/safety_eye_protection{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/medical/chemistry)
 "cCm" = (
 /obj/structure/shuttle/engine/propulsion/left{
 	dir = 8;
@@ -3872,6 +4135,20 @@
 	},
 /turf/open/floor/plating/airless,
 /area/medical/abandoned)
+"cEI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/crew_quarters/dorms)
 "cEO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
@@ -3957,6 +4234,12 @@
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/engine/supermatter)
+"cGm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/science/test_area)
 "cGI" = (
 /obj/structure/window/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -3968,7 +4251,7 @@
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "cHn" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -4027,8 +4310,12 @@
 	dir = 4
 	},
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
+"cJz" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine/airless,
+/area/ruin/space/derelict/storage/equipment)
 "cJG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -4038,7 +4325,9 @@
 	name = "emergency shower"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/showroomfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/crew_quarters/cryopods)
 "cJH" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4048,6 +4337,16 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark/airless,
 /area/science/research/abandoned)
+"cKe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/wood/airless,
+/area/crew_quarters/dorms)
 "cKf" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -4095,6 +4394,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood/splatter,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "cLn" = (
@@ -4229,6 +4531,10 @@
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/hydroponics/garden/abandoned)
+"cVQ" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/crew_quarters/theatre)
 "cWd" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/airless,
@@ -4239,6 +4545,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/engine/supermatter)
+"cWp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/closed/wall,
+/area/hydroponics/garden/abandoned)
 "cXe" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -4270,7 +4582,8 @@
 /area/library/abandoned)
 "cYu" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark/airless,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "cYy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4327,6 +4640,9 @@
 /obj/item/paicard{
 	pixel_x = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/crew_quarters/fitness)
 "daF" = (
@@ -4339,6 +4655,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/derelict/hallway)
 "dbl" = (
@@ -4373,7 +4690,7 @@
 	pixel_y = -5
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/derelict/hallway)
+/area/ruin/space/derelict/atmospherics)
 "dcm" = (
 /turf/closed/wall,
 /area/ruin/space/derelict/singularity_engine)
@@ -4383,13 +4700,22 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/engine/supermatter)
+/area/space/nearstation)
 "dcx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
+"dcz" = (
+/obj/machinery/door/window/southleft,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden/abandoned)
 "dcA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -4439,9 +4765,7 @@
 /area/ruin/space/derelict/singularity_engine)
 "deC" = (
 /obj/structure/girder,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
+/turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "deE" = (
 /obj/structure/grille,
@@ -4498,14 +4822,30 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
+"dhP" = (
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/science/test_area)
 "din" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/air_sensor/atmos/toxins_mixing_tank,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
+"diw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/beacon,
+/obj/item/beacon,
+/turf/open/floor/plasteel/dark/airless,
+/area/maintenance/department/eva)
 "diI" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -4520,6 +4860,12 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"dje" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/security/prison)
 "djL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown,
@@ -4621,7 +4967,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/derelict/storage/equipment)
 "dmE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4658,7 +5004,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "dpl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4679,6 +5025,17 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/supermatter)
+"dqe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/dark/airless,
+/area/crew_quarters/fitness)
 "dqF" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -4867,6 +5224,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/crew_quarters/fitness)
 "dxy" = (
@@ -4896,6 +5256,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/random{
 	pixel_x = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -4962,6 +5325,10 @@
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
 "dAo" = (
@@ -4977,7 +5344,7 @@
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "dAZ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5004,7 +5371,7 @@
 	pixel_y = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/mineral/plastitanium/airless,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "dBA" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -5056,7 +5423,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/killertomato,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "dDL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5115,7 +5482,7 @@
 /obj/effect/turf_decal/tile/green,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/killertomato,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "dFY" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -5179,7 +5546,7 @@
 	dir = 8
 	},
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "dIF" = (
 /obj/effect/turf_decal/tile/blue{
@@ -5197,7 +5564,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "dIU" = (
 /obj/effect/turf_decal/tile/blue{
@@ -5212,9 +5579,19 @@
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/bridge)
 "dJV" = (
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/library/abandoned)
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm{
+	dir = 2;
+	pixel_y = 22
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/medical/chemistry)
 "dJW" = (
 /obj/machinery/computer/security{
 	dir = 4
@@ -5249,6 +5626,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
+"dKI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/science/test_area)
 "dLb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/pipe,
@@ -5287,7 +5672,7 @@
 "dMF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine/air,
-/area/ruin/space/derelict/hallway)
+/area/ruin/space/derelict/atmospherics)
 "dNa" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste,
 /obj/structure/lattice/catwalk,
@@ -5386,8 +5771,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
@@ -5460,6 +5848,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"dSe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/science/research/abandoned)
 "dTf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -5484,7 +5885,7 @@
 "dTq" = (
 /obj/structure/sign/poster/contraband/power,
 /turf/closed/wall,
-/area/ruin/space/derelict/hallway)
+/area/ruin/space/derelict/atmospherics)
 "dTw" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -5507,6 +5908,15 @@
 "dUM" = (
 /turf/open/floor/plating/airless,
 /area/medical/abandoned)
+"dUN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/crew_quarters/cryopods)
 "dVa" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -5533,6 +5943,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark/airless,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "dVT" = (
@@ -5689,6 +6100,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark/airless,
 /area/crew_quarters/fitness)
 "eaa" = (
@@ -5726,6 +6139,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
+"eaq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/science/test_area)
 "eaQ" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/chair/comfy/shuttle{
@@ -5736,7 +6155,7 @@
 	},
 /obj/machinery/light/broken,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/mineral/plastitanium/airless,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "ebk" = (
 /obj/machinery/light/small{
@@ -5744,6 +6163,12 @@
 	},
 /turf/open/floor/plasteel/stairs/right,
 /area/library)
+"ebu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/closed/wall,
+/area/hydroponics/garden/abandoned)
 "ebE" = (
 /obj/machinery/camera/autoname,
 /turf/open/floor/plating,
@@ -5795,11 +6220,16 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark/airless,
 /area/hallway/secondary/command)
 "ecE" = (
-/turf/closed/wall,
-/area/ruin/space/has_grav/deepstorage/power)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/security/prison)
 "ecH" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/neutral{
@@ -5821,7 +6251,7 @@
 	dir = 4
 	},
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "edl" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -5879,10 +6309,15 @@
 	name = "Command EVA"
 	})
 "ehk" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/area/science/research/abandoned)
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "ehT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/window,
@@ -6079,7 +6514,7 @@
 /obj/effect/turf_decal/tile/green,
 /obj/machinery/hydroponics/constructable,
 /obj/item/shovel/spade,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "eqj" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -6101,11 +6536,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
 /obj/structure/sign/poster/random{
 	pixel_y = -32
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
@@ -6226,11 +6663,10 @@
 /area/maintenance/starboard/aft)
 "etk" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
+	dir = 4
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/engine/supermatter)
+/area/space/nearstation)
 "etq" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/decal/cleanable/dirt,
@@ -6261,6 +6697,18 @@
 /area/crew_quarters/heads/captain/private{
 	name = "Admiral's Quarters"
 	})
+"etX" = (
+/obj/structure/sign/directions/engineering{
+	dir = 8;
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/command,
+/obj/structure/sign/directions/supply{
+	dir = 4;
+	pixel_y = 8
+	},
+/turf/closed/wall,
+/area/hydroponics/garden/abandoned)
 "eub" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue{
@@ -6503,6 +6951,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"eCQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/medical/genetics)
 "eCU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -6510,7 +6964,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/derelict/hallway)
+/area/ruin/space/derelict/atmospherics)
 "eDx" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -6537,7 +6991,7 @@
 /obj/structure/sign/departments/minsky/supply/hydroponics{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "eDP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6547,6 +7001,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark/airless,
 /area/hallway/secondary/command)
 "eEc" = (
@@ -6582,6 +7040,12 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/hallway/secondary/command)
@@ -6721,14 +7185,14 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
 "eJp" = (
@@ -6839,6 +7303,15 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"eLG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/target,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/science/test_area)
 "eOo" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6915,11 +7388,25 @@
 	},
 /turf/open/space/basic,
 /area/science/research/abandoned)
+"eRL" = (
+/obj/machinery/mass_driver{
+	id = "toxinsdriver"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/southleft{
+	dir = 8;
+	name = "Mass Driver Door";
+	req_access_txt = "7"
+	},
+/turf/open/floor/plating/airless,
+/area/science/research/abandoned)
 "eRY" = (
 /obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
 /turf/open/floor/plating/airless,
 /area/medical/chemistry)
@@ -6933,7 +7420,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel/showroomfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/crew_quarters/cryopods)
 "eTd" = (
 /obj/machinery/light/small{
@@ -7038,6 +7528,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
+"eWv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/east{
+	start_charge = 0
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/science/research/abandoned)
 "eWW" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Access";
@@ -7055,7 +7559,7 @@
 	name = "Misc Supplies";
 	req_access_txt = "201"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/derelict/storage/equipment)
 "eXT" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -7107,10 +7611,20 @@
 /area/quartermaster/miningdock)
 "eZO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+	dir = 6
 	},
 /turf/closed/wall,
 /area/ruin/space/derelict/hallway)
+"eZR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/wood/airless,
+/area/crew_quarters/dorms)
 "fap" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/airless{
@@ -7192,6 +7706,14 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark/airless,
 /area/medical/chemistry)
+"fbR" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/science/test_area)
 "fci" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -7233,7 +7755,7 @@
 /obj/machinery/door/airlock/external{
 	name = "Escape Airlock"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/airless,
 /area/library/abandoned)
 "fer" = (
 /obj/effect/turf_decal/tile/brown,
@@ -7302,6 +7824,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"fhN" = (
+/obj/structure/grille,
+/turf/closed/wall,
+/area/space/nearstation)
 "fii" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -7353,12 +7879,10 @@
 /area/ai_monitored/turret_protected/ai)
 "fjr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "fjS" = (
@@ -7388,6 +7912,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"fks" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "fkx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -7524,6 +8055,10 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"fqJ" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/layer3,
+/turf/open/floor/plating/airless,
+/area/hydroponics/garden/abandoned)
 "fqT" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -7542,6 +8077,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
 /turf/open/floor/wood/airless,
 /area/crew_quarters/dorms)
 "fqZ" = (
@@ -7606,6 +8144,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/bridge)
 "ftu" = (
@@ -7646,7 +8190,7 @@
 /area/hallway/primary/starboard)
 "ftR" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/ruin/space/derelict/gravity_generator)
 "fug" = (
@@ -7829,12 +8373,7 @@
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "fxz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/light/small/broken,
-/turf/open/floor/plasteel/dark/airless,
+/turf/closed/wall,
 /area/crew_quarters/theatre)
 "fyr" = (
 /obj/structure/cable/yellow{
@@ -7856,6 +8395,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
+"fyz" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3,
+/turf/open/floor/plating/airless,
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "fyO" = (
 /obj/item/cigbutt,
 /obj/effect/decal/cleanable/dirt,
@@ -7927,14 +8470,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"fBB" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/vacuum,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "fBJ" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hop)
+"fBW" = (
+/obj/machinery/doppler_array/research/science{
+	dir = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/science/research/abandoned)
 "fCh" = (
 /obj/structure/grille,
 /turf/open/space/basic,
@@ -7966,7 +8518,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shard,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "fCu" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8029,6 +8581,10 @@
 /obj/structure/sign/poster/contraband/smoke{
 	pixel_x = -32
 	},
+/obj/structure/sign/warning/radiation/rad_area{
+	dir = 1;
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/gravity_generator)
 "fES" = (
@@ -8065,6 +8621,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plasteel/dark/airless,
 /area/ai_monitored/turret_protected/ai_upload)
 "fEX" = (
@@ -8079,9 +8636,6 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
@@ -8246,8 +8800,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
+	},
 /obj/machinery/atmospherics/components/binary/dp_vent_pump{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
@@ -8286,7 +8843,9 @@
 "fLD" = (
 /obj/item/bodypart/chest,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/showroomfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/crew_quarters/cryopods)
 "fLE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8348,9 +8907,6 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"fNM" = (
-/turf/open/space/basic,
-/area/engine/supermatter)
 "fNX" = (
 /obj/machinery/telecomms/broadcaster/preset_left,
 /obj/effect/decal/cleanable/dirt,
@@ -8370,8 +8926,16 @@
 /obj/effect/turf_decal/tile/green,
 /obj/machinery/hydroponics/constructable,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
+"fOZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/bridge/meeting_room/council)
 "fPe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -8380,12 +8944,12 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room/council)
 "fPr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/sign/nanotrasen,
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/space/derelict/hallway)
+/turf/closed/wall,
+/area/crew_quarters/theatre)
 "fPt" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -8418,7 +8982,7 @@
 /area/engine/supermatter)
 "fQk" = (
 /obj/item/clothing/head/helmet/space/eva,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "fQs" = (
 /obj/effect/turf_decal/tile/blue{
@@ -8451,6 +9015,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark/airless,
 /area/hallway/secondary/command)
 "fSW" = (
@@ -8464,6 +9030,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/singularity_engine)
+"fSY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "fUU" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -8487,7 +9060,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/green,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "fVd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8696,7 +9269,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plating,
 /area/ruin/space/derelict/hallway)
 "fYU" = (
 /obj/machinery/meter,
@@ -8714,6 +9287,12 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "fZj" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
 /turf/open/floor/plating/airless{
 	icon_state = "panelscorched"
 	},
@@ -8853,6 +9432,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark/airless,
 /area/crew_quarters/fitness)
 "geS" = (
@@ -8861,10 +9442,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/decal/cleanable/blood/gibs/bubblegum,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/blood/gibs/bubblegum,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "geX" = (
@@ -8912,11 +9493,8 @@
 "ghV" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/airless,
@@ -8986,6 +9564,14 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"gjp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel/dark/airless,
+/area/medical/chemistry)
 "gjW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
@@ -9043,6 +9629,7 @@
 /area/crew_quarters/heads/hop)
 "gli" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "glk" = (
@@ -9073,6 +9660,8 @@
 /obj/structure/sign/poster/random{
 	pixel_x = 32
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark/airless,
 /area/crew_quarters/fitness)
 "gmn" = (
@@ -9124,6 +9713,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"gmV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/dresser,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/machinery/button/door{
+	id = "Cabin4";
+	name = "Cabin Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = -25;
+	specialfunctions = 4
+	},
+/turf/open/floor/wood/airless,
+/area/crew_quarters/dorms)
 "gmW" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -9204,13 +9806,15 @@
 	},
 /obj/machinery/hydroponics/constructable,
 /obj/item/seeds/carrot,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "gpy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark/airless,
 /area/crew_quarters/dorms)
 "gqj" = (
@@ -9310,7 +9914,7 @@
 "grZ" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
-/area/ruin/space/derelict/hallway)
+/area/ruin/space/derelict/atmospherics)
 "gsc" = (
 /turf/closed/wall/r_wall,
 /area/security/brig)
@@ -9329,6 +9933,14 @@
 "guF" = (
 /turf/closed/wall,
 /area/security/prison)
+"guY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/window,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/medical/chemistry)
 "gvK" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -9452,14 +10064,37 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/derelict/hallway)
-"gyR" = (
+/area/ruin/space/derelict/atmospherics)
+"gyn" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel/dark/airless,
+/area/crew_quarters/fitness)
+"gyD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/turf/closed/wall,
+/area/hallway/secondary/exit)
+"gyR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/science/research/abandoned)
@@ -9475,7 +10110,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plating,
 /area/ruin/space/derelict/hallway)
 "gzh" = (
 /turf/open/floor/plating/airless{
@@ -9513,7 +10148,7 @@
 	name = "air tank output inlet"
 	},
 /turf/open/floor/engine/air,
-/area/ruin/space/derelict/hallway)
+/area/ruin/space/derelict/atmospherics)
 "gAB" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -9635,7 +10270,10 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark/airless,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "gEx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9645,7 +10283,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/suit_storage_unit/standard_unit,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/eva)
 "gEK" = (
@@ -9770,7 +10417,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "gIu" = (
 /obj/effect/turf_decal/tile/red{
@@ -9858,8 +10505,12 @@
 /obj/structure/sign/warning/pods{
 	name = "MINING POD"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/door/firedoor/window,
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
@@ -9918,7 +10569,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/derelict/hallway)
+/area/ruin/space/derelict/atmospherics)
 "gKo" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -9939,7 +10590,18 @@
 "gLu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
+/area/ruin/space/derelict/atmospherics)
+"gLC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/closed/wall,
 /area/ruin/space/derelict/hallway)
+"gLD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel/dark/airless,
+/area/crew_quarters/fitness)
 "gNn" = (
 /turf/closed/wall/r_wall,
 /area/mine/eva{
@@ -10043,6 +10705,12 @@
 /area/ruin/space/derelict/bridge)
 "gQi" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
 	},
@@ -10142,6 +10810,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark/airless,
 /area/bridge/showroom/corporate)
 "gUI" = (
@@ -10219,10 +10889,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/turf/open/floor/plating/airless{
-	icon_state = "platingdmg3"
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
+	dir = 1
 	},
-/area/ruin/space/derelict/arrival)
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "gVZ" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Break Room";
@@ -10307,6 +10978,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
+"gXv" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/exit)
 "gYj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/purple,
@@ -10362,7 +11040,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/library/abandoned)
 "haO" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -10406,7 +11084,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "hcU" = (
@@ -10552,6 +11232,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/bridge)
 "hki" = (
@@ -10593,7 +11279,11 @@
 	name = "kitty door";
 	req_access_txt = "200"
 	},
-/turf/open/floor/engine,
+/obj/machinery/door/window/northleft{
+	name = "kitty door";
+	req_access_txt = "200"
+	},
+/turf/open/floor/engine/airless,
 /area/ruin/space/derelict/storage/equipment)
 "hkY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10678,8 +11368,11 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "hnP" = (
-/turf/open/floor/plating,
-/area/library/abandoned)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space)
 "hof" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
@@ -10773,6 +11466,12 @@
 /obj/effect/mob_spawn/human/corpse/nanotrasensoldier,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/bridge)
@@ -10926,6 +11625,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark/airless,
 /area/library/abandoned)
+"hwl" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg2"
+	},
+/area/space/nearstation)
 "hwJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
@@ -11113,7 +11818,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "hJx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11192,7 +11897,7 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/ruin/space/derelict/hallway)
+/area/ruin/space/derelict/atmospherics)
 "hLz" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -11317,7 +12022,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/suit_storage_unit/standard_unit,
+/obj/structure/tank_dispenser/oxygen{
+	pixel_x = -1;
+	pixel_y = 2
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/eva)
 "hPE" = (
@@ -11485,6 +12193,12 @@
 	name = "Dorm 5"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
 /turf/open/floor/wood/airless,
 /area/crew_quarters/dorms)
 "hUn" = (
@@ -11563,7 +12277,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/showroomfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/crew_quarters/cryopods)
 "hVw" = (
 /obj/effect/turf_decal/stripes/line{
@@ -11627,7 +12343,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "hWA" = (
 /obj/structure/lattice,
@@ -11736,7 +12452,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "hZr" = (
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
 /area/engine/gravity_generator)
@@ -11766,7 +12482,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "iaE" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -11824,6 +12540,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
+"idi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/derelict/bridge)
+"idD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/mine/eva{
+	name = "Command EVA"
+	})
 "idO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -11877,6 +12611,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark/airless,
 /area/library/abandoned)
+"ifd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/medical/chemistry)
 "igB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced{
@@ -11912,7 +12664,7 @@
 "igU" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
-/area/ruin/space/derelict/hallway)
+/area/ruin/space/derelict/atmospherics)
 "iha" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/northleft{
@@ -11960,8 +12712,14 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
 "ihK" = (
-/turf/open/floor/plating,
-/area/hydroponics/garden/abandoned)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/turf/closed/wall,
+/area/medical/chemistry)
 "iiE" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Command Centre";
@@ -11983,7 +12741,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -12040,10 +12797,20 @@
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"ikv" = (
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'BOMB RANGE";
+	name = "BOMB RANGE"
+	},
+/turf/closed/wall/r_wall,
+/area/science/research/abandoned)
 "ikF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/science/research/abandoned)
@@ -12052,6 +12819,11 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/ruin/space/has_grav/deepstorage/power)
+"ikT" = (
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/derelict/singularity_engine)
 "ilr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue{
@@ -12066,6 +12838,12 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/crew_quarters/heads/captain/private{
@@ -12153,9 +12931,14 @@
 /area/hydroponics)
 "ipZ" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness)
+"iqg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/exit)
 "iqr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/nanotrasen{
@@ -12164,6 +12947,12 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/bridge)
@@ -12214,7 +13003,10 @@
 	dir = 8
 	},
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/dark/airless,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "ise" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -12245,6 +13037,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"itA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/science/test_area)
 "itZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -12272,6 +13070,17 @@
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/engine/supermatter)
+"ivv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/dark/airless,
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "ivS" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -12282,6 +13091,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark/airless,
 /area/crew_quarters/fitness)
+"iwo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/exit)
 "iwp" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -12301,7 +13117,7 @@
 /obj/structure/sign/departments/minsky/engineering/engineering{
 	pixel_x = 32
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "platingdmg3"
 	},
 /area/ruin/space/derelict/singularity_engine)
@@ -12329,6 +13145,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/random{
 	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -12385,6 +13204,12 @@
 	icon_state = "platingdmg2"
 	},
 /area/ai_monitored/turret_protected/ai_upload)
+"iBq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plating/airless,
+/area/science/test_area)
 "iBz" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -12449,6 +13274,9 @@
 "iFe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/wood{
@@ -12597,7 +13425,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
-/area/ruin/space/derelict/hallway)
+/area/ruin/space/derelict/atmospherics)
 "iIG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -12606,9 +13434,6 @@
 /turf/open/floor/plasteel/dark/airless,
 /area/quartermaster/storage)
 "iJH" = (
-/obj/structure/sign/warning/securearea{
-	pixel_y = 32
-	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/hallway)
 "iJX" = (
@@ -12636,7 +13461,13 @@
 /obj/machinery/suit_storage_unit/engine,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/derelict/hallway)
+/area/ruin/space/derelict/atmospherics)
+"iKH" = (
+/obj/structure/sign/departments/minsky/engineering/engineering{
+	pixel_y = 32
+	},
+/turf/open/space/basic,
+/area/space)
 "iLA" = (
 /obj/structure/sign/poster/official/help_others,
 /turf/closed/wall,
@@ -12671,7 +13502,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/gravity_generator)
 "iMa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -12715,13 +13546,15 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "iNx" = (
-/obj/machinery/door/window/southleft,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/green,
-/turf/open/floor/plasteel/dark/airless,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "iNJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12739,9 +13572,12 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "iOc" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/ruin/space/derelict/storage/equipment)
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "iOl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -12875,6 +13711,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark/airless,
 /area/bridge/showroom/corporate)
 "iRa" = (
@@ -12887,6 +13725,12 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/crew_quarters/dorms)
 "iRc" = (
@@ -12931,6 +13775,7 @@
 	name = "Chapel Hall"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/hallway/primary/port)
 "iTx" = (
@@ -12970,13 +13815,10 @@
 "iTP" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/border_only/closed{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only/closed{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "iTT" = (
@@ -12993,6 +13835,12 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plasteel/dark/airless,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
+"iUB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/closed/wall,
+/area/hallway/secondary/exit)
 "iUU" = (
 /obj/item/roller,
 /obj/effect/turf_decal/tile/blue{
@@ -13036,8 +13884,25 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
+"iXa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 2;
+	pixel_y = 22
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/derelict/hallway)
 "iXk" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -13059,6 +13924,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"iXw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/closed/wall,
+/area/hallway/secondary/exit)
 "iXK" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -13115,7 +13986,9 @@
 	name = "emergency shower"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/showroomfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/crew_quarters/cryopods)
 "iZM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13128,6 +14001,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
+	},
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/hydroponics/garden/abandoned)
@@ -13198,7 +14077,7 @@
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/under/color/grey,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "jcV" = (
 /obj/effect/turf_decal/tile/blue,
@@ -13351,13 +14230,22 @@
 	pixel_y = -5
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/derelict/hallway)
+/area/ruin/space/derelict/atmospherics)
 "jgz" = (
-/obj/structure/girder,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/area/quartermaster/storage)
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel/dark/airless,
+/area/medical/chemistry)
 "jgF" = (
 /obj/machinery/atmospherics/components/trinary/filter/critical{
 	dir = 4
@@ -13382,6 +14270,12 @@
 	name = "Dorm 1"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
 /turf/open/floor/wood/airless,
 /area/crew_quarters/dorms)
 "jhw" = (
@@ -13396,6 +14290,13 @@
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/abandoned_tele)
+"jhz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "jib" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -13500,6 +14401,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"joe" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/item/target,
+/turf/open/floor/plating/airless,
+/area/science/test_area)
+"joz" = (
+/obj/machinery/door/window/southright,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden/abandoned)
 "joM" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -13640,11 +14557,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"jvm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/exit)
 "jvM" = (
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/command)
 "jvO" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "jvT" = (
@@ -13671,19 +14596,46 @@
 "jwX" = (
 /turf/closed/wall/r_wall,
 /area/bridge)
+"jxr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/command/glass{
+	name = "AI Upload Access";
+	req_access_txt = "19"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/bridge/showroom/corporate)
 "jxG" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/closet,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "jxK" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/derelict/bridge)
+"jzT" = (
+/turf/open/floor/plating/airless,
+/area/science/test_area)
 "jAb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -13769,6 +14721,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"jBF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/dresser,
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/machinery/button/door{
+	id = "Cabin4";
+	name = "Cabin Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = -25;
+	specialfunctions = 4
+	},
+/turf/open/floor/wood/airless,
+/area/crew_quarters/dorms)
 "jCk" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
@@ -13880,6 +14848,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"jGz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/storage/belt/utility,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/open/floor/plasteel,
+/area/maintenance/department/eva)
 "jGC" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -14049,6 +15030,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
@@ -14195,6 +15178,14 @@
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/machinery/button/door{
+	id = "Cabin3";
+	name = "Cabin Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 25;
+	specialfunctions = 4
+	},
 /turf/open/floor/wood/airless,
 /area/crew_quarters/dorms)
 "jRd" = (
@@ -14226,7 +15217,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/ruin/space/derelict/hallway)
 "jSl" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
@@ -14254,13 +15245,16 @@
 /obj/structure/rack,
 /obj/item/circuitboard/computer/teleporter,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plasteel/dark/airless,
 /area/science/research/abandoned)
 "jSB" = (
@@ -14301,9 +15295,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/structure/sign/warning/securearea{
-	pixel_y = -32
-	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/hallway)
 "jUA" = (
@@ -14343,7 +15334,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/mineral/plastitanium/airless,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "jWT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14358,7 +15349,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/storage/equipment)
 "jXY" = (
 /turf/open/floor/circuit/airless,
@@ -14377,6 +15368,12 @@
 /area/crew_quarters/kitchen)
 "jYH" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken4"
 	},
@@ -14390,7 +15387,7 @@
 /obj/machinery/suit_storage_unit/open,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/derelict/hallway)
+/area/ruin/space/derelict/atmospherics)
 "jZR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -14472,7 +15469,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "kcm" = (
-/obj/machinery/door/window/northleft,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -14480,7 +15476,10 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark/airless,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "kcu" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -14634,6 +15633,10 @@
 /obj/item/restraints/legcuffs/beartrap,
 /turf/open/floor/plasteel/airless/dark,
 /area/science/research/abandoned)
+"kfp" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/closed/wall,
+/area/hallway/secondary/exit)
 "kgd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -14649,7 +15652,10 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark/airless,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "kgo" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14699,7 +15705,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "kgY" = (
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "panelscorched"
 	},
 /area/engine/gravity_generator)
@@ -14741,6 +15747,9 @@
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/box,
 /obj/item/storage/toolbox/mechanical,
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/bridge)
 "kjm" = (
@@ -14883,7 +15892,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/derelict/hallway)
+/area/ruin/space/derelict/atmospherics)
 "knB" = (
 /obj/machinery/rnd/server,
 /obj/effect/decal/cleanable/dirt,
@@ -14906,6 +15915,10 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "knM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
 "knV" = (
@@ -14955,6 +15968,9 @@
 	},
 /obj/structure/closet/secure_closet/medical1,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "kpU" = (
@@ -14976,6 +15992,11 @@
 	},
 /turf/open/floor/plating,
 /area/medical/abandoned)
+"kqz" = (
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plating/airless,
+/area/hydroponics/garden/abandoned)
 "kqC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
@@ -15014,13 +16035,26 @@
 "krG" = (
 /turf/closed/mineral,
 /area/mine/unexplored)
+"krI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/derelict/bridge)
 "kta" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/engine/air,
-/area/ruin/space/derelict/hallway)
+/area/ruin/space/derelict/atmospherics)
 "kth" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue{
@@ -15173,7 +16207,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/showroomfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/crew_quarters/cryopods)
 "kwn" = (
 /obj/effect/turf_decal/tile/blue{
@@ -15195,7 +16231,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/ruin/space/derelict/hallway)
 "kwW" = (
 /obj/machinery/computer/communications,
@@ -15232,6 +16268,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark/airless,
 /area/crew_quarters/fitness)
 "kAf" = (
@@ -15358,18 +16396,12 @@
 "kFv" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/border_only/closed{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only/closed{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/binary/pump/on/layer1{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
@@ -15474,7 +16506,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "platingdmg3"
 	},
 /area/quartermaster/storage)
@@ -15487,7 +16519,9 @@
 	name = "emergency shower"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/showroomfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/crew_quarters/cryopods)
 "kIM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -15618,8 +16652,15 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
+"kOS" = (
+/obj/structure/window/fulltile,
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/science/test_area)
 "kPa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/warning/securearea{
@@ -15687,7 +16728,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/derelict/hallway)
 "kQW" = (
@@ -15773,14 +16813,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/sign/warning/securearea{
-	pixel_y = 32
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
 /area/ruin/space/derelict/hallway)
 "kVB" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -15950,7 +16992,7 @@
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "lap" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -15991,7 +17033,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "lcB" = (
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "platingdmg3"
 	},
 /area/engine/gravity_generator)
@@ -16096,6 +17138,11 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"lgM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/plasteel/dark/airless,
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "lgP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/departments/security{
@@ -16107,10 +17154,14 @@
 	name = "dead plant";
 	pixel_y = 8
 	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "lhh" = (
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
 /area/ruin/space/derelict/singularity_engine)
@@ -16151,6 +17202,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"lme" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/hydroponics/garden/abandoned)
 "lmC" = (
 /obj/machinery/computer/bank_machine,
 /obj/effect/turf_decal/bot_white,
@@ -16223,6 +17280,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark/airless,
 /area/medical/chemistry)
+"lpf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "lpP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -16273,6 +17337,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"lru" = (
+/obj/machinery/door/poddoor{
+	id = "toxinsdriver";
+	name = "Toxins Launcher Bay Door"
+	},
+/turf/open/floor/plating/airless,
+/area/science/research/abandoned)
 "lrB" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -16312,6 +17383,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/derelict/hallway)
+"lsh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/science/research/abandoned)
 "lsj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral,
@@ -16346,6 +17430,33 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"lsM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel/showroomfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/crew_quarters/cryopods)
+"lsW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/crew_quarters/dorms)
 "ltz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue{
@@ -16455,9 +17566,6 @@
 /area/engine/gravity_generator)
 "lwg" = (
 /obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -16471,16 +17579,16 @@
 	dir = 4
 	},
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/dark/airless,
-/area/hydroponics/garden/abandoned)
-"lwp" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden/abandoned)
+"lwp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/science/research/abandoned)
 "lwZ" = (
@@ -16532,6 +17640,14 @@
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/ai_monitored/security/armory)
+"lyM" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/mine/eva{
+	name = "Command EVA"
+	})
 "lyT" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/structure/window/reinforced{
@@ -16612,6 +17728,19 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/science/lab)
+"lAY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/derelict/bridge)
 "lBA" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -16654,7 +17783,7 @@
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "lDi" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16824,6 +17953,12 @@
 /area/ruin/space/derelict/storage/equipment)
 "lIV" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg3"
 	},
@@ -16861,9 +17996,25 @@
 	icon_state = "platingdmg3"
 	},
 /area/science/research/abandoned)
+"lJV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/crew_quarters/fitness)
 "lJW" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/engine/gravity_generator)
 "lKN" = (
@@ -16883,6 +18034,9 @@
 /area/ruin/space/derelict/storage/equipment)
 "lLx" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plating/airless{
 	icon_state = "panelscorched"
 	},
@@ -16902,7 +18056,7 @@
 /obj/structure/sign/poster/random{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "lNE" = (
 /obj/effect/turf_decal/tile/yellow,
@@ -16961,6 +18115,9 @@
 "lOl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/medical/chemistry)
 "lOn" = (
@@ -16974,6 +18131,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
@@ -17093,6 +18256,10 @@
 	dir = 4;
 	name = "Command blue corner"
 	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/bridge/showroom/corporate)
 "lRt" = (
@@ -17126,16 +18293,16 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -17270,6 +18437,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"lYP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/theatre)
 "lYR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -17318,6 +18495,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark/airless,
 /area/mine/eva{
 	name = "Command EVA"
@@ -17449,6 +18627,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark/airless,
 /area/crew_quarters/cryopods)
 "mdj" = (
@@ -17539,6 +18719,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/storage/equipment)
+"mgs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/dark/airless,
+/area/crew_quarters/dorms)
 "mgE" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -17619,6 +18808,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark/airless,
 /area/hallway/secondary/command)
 "mlm" = (
@@ -17630,6 +18823,13 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/dark/airless,
 /area/medical/abandoned)
+"mlt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/weightmachine/stacklifter,
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel/dark/airless,
+/area/crew_quarters/fitness)
 "mlw" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -17667,7 +18867,8 @@
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
-/obj/machinery/suit_storage_unit/open,
+/obj/structure/closet/toolcloset,
+/obj/item/multitool,
 /turf/open/floor/plasteel,
 /area/maintenance/department/eva)
 "mmx" = (
@@ -17691,7 +18892,7 @@
 "mmS" = (
 /obj/structure/girder,
 /turf/open/floor/plating/airless,
-/area/ruin/space/has_grav/deepstorage/power)
+/area/space/nearstation)
 "mnz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -17785,7 +18986,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/suit_storage_unit/open,
+/obj/structure/table,
+/obj/item/stack/sheet/rglass,
+/obj/item/stack/sheet/rglass,
+/obj/item/stack/sheet/rglass,
+/obj/item/stack/sheet/rglass,
+/obj/item/crowbar/large,
 /turf/open/floor/plasteel,
 /area/maintenance/department/eva)
 "mre" = (
@@ -17847,7 +19053,7 @@
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "mvk" = (
 /obj/effect/turf_decal/tile/purple{
@@ -17905,6 +19111,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
 /area/bridge/meeting_room/council)
 "mwe" = (
@@ -17953,6 +19161,12 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/autoname,
+/obj/machinery/button/door{
+	id = "evashutter";
+	name = "E.V.A. Storage Shutter Control";
+	pixel_y = 25;
+	req_access_txt = "19"
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
 "mzJ" = (
@@ -18002,13 +19216,13 @@
 "mBd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/frame/computer,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark/airless,
@@ -18022,6 +19236,12 @@
 /obj/machinery/light/small/broken,
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/singularity_engine)
+"mBn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/ruin/space/derelict/hallway)
 "mBw" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -18045,7 +19265,10 @@
 	dir = 4
 	},
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/dark/airless,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "mCe" = (
 /obj/effect/turf_decal/tile/green{
@@ -18135,6 +19358,14 @@
 /obj/item/circuitboard/machine/protolathe/department/service,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
+"mFr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating/airless{
+	icon_state = "panelscorched"
+	},
+/area/science/test_area)
 "mFF" = (
 /obj/machinery/computer/med_data{
 	dir = 1
@@ -18176,6 +19407,12 @@
 	},
 /turf/open/floor/plating/airless,
 /area/library/abandoned)
+"mHN" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/hydroponics/garden/abandoned)
 "mJl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue,
@@ -18188,6 +19425,22 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/bridge/access)
+"mKc" = (
+/obj/structure/sign/directions/medical{
+	dir = 8
+	},
+/turf/closed/wall,
+/area/ruin/space/derelict/arrival)
+"mKB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "mKI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
@@ -18300,17 +19553,10 @@
 /area/ai_monitored/storage/eva)
 "mNB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel/dark/airless,
+/turf/closed/wall,
 /area/crew_quarters/theatre)
 "mOp" = (
 /obj/effect/decal/cleanable/dirt,
@@ -18350,6 +19596,9 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "mPN" = (
@@ -18386,7 +19635,7 @@
 /obj/structure/closet/crate/internals,
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/mineral/plastitanium/airless,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "mQp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -18407,11 +19656,11 @@
 /area/medical/abandoned)
 "mQY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
@@ -18438,6 +19687,12 @@
 	pixel_x = 7;
 	pixel_y = 26;
 	req_access_txt = "19"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/bridge)
@@ -18470,6 +19725,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
 "mTZ" = (
@@ -18503,6 +19760,13 @@
 /obj/machinery/air_sensor/atmos/air_tank,
 /turf/open/floor/engine/air,
 /area/engine/atmos)
+"mUU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/crew_quarters/fitness)
 "mVc" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -18545,12 +19809,23 @@
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/security/armory)
+"mVD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/plating/airless,
+/area/crew_quarters/dorms)
 "mVY" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood{
-	icon_state = "wood-broken"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
-/area/crew_quarters/dorms)
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "mWa" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/neutral{
@@ -18610,7 +19885,6 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
 "mWS" = (
-/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -18623,7 +19897,7 @@
 	dir = 8
 	},
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "mXo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
@@ -18775,6 +20049,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
+"ncz" = (
+/obj/structure/sign/directions/science{
+	pixel_y = -8
+	},
+/turf/closed/wall/r_wall,
+/area/science/research/abandoned)
 "ncT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -18858,14 +20138,28 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
-"nfs" = (
-/obj/machinery/door/firedoor/border_only/closed{
-	dir = 1
+"neV" = (
+/obj/structure/sign/directions/command{
+	dir = 4;
+	pixel_y = 34
 	},
-/obj/machinery/door/firedoor/border_only/closed,
+/obj/structure/sign/directions/supply{
+	dir = 1;
+	pixel_y = 42
+	},
+/turf/open/space/basic,
+/area/science/research/abandoned)
+"nfs" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
@@ -18896,8 +20190,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/science/research/abandoned)
+/area/hallway/secondary/exit)
 "ngH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/mining{
@@ -19012,6 +20309,17 @@
 /obj/effect/decal/remains/robot,
 /turf/open/floor/plasteel/dark/airless,
 /area/science/research/abandoned)
+"nmk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mob_spawn/human/corpse/nanotrasensoldier,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/derelict/bridge)
 "nmI" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -19035,6 +20343,12 @@
 	name = "Dorm 6"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
 /turf/open/floor/wood/airless,
 /area/crew_quarters/dorms)
 "nmO" = (
@@ -19048,7 +20362,7 @@
 	dir = 8
 	},
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "nmT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19089,6 +20403,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/crew_quarters/dorms)
 "nob" = (
@@ -19111,6 +20428,19 @@
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/library/abandoned)
+"nom" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/crew_quarters/fitness)
 "nop" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -19262,7 +20592,7 @@
 	},
 /obj/machinery/hydroponics/constructable,
 /obj/item/seeds/cannabis,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "nsp" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19358,9 +20688,11 @@
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/arrival)
 "nxN" = (
-/turf/open/floor/plating/airless{
-	icon_state = "panelscorched"
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
+/turf/open/floor/plating,
 /area/crew_quarters/theatre)
 "nxU" = (
 /obj/machinery/power/generator,
@@ -19413,7 +20745,7 @@
 	},
 /obj/item/flashlight,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/mineral/plastitanium/airless,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "nzD" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -19430,9 +20762,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/derelict/hallway)
 "nBe" = (
@@ -19525,7 +20855,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/ruin/space/derelict/hallway)
 "nEb" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19560,6 +20890,8 @@
 	icon_state = "1-2"
 	},
 /mob/living/simple_animal/hostile/carp,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark/airless,
 /area/crew_quarters/dorms)
 "nFk" = (
@@ -19567,10 +20899,10 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "nFp" = (
@@ -19581,12 +20913,15 @@
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "nFM" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/random{
+	pixel_x = 32
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/supermatter)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "nGl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -19600,6 +20935,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port)
+"nGO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/mine/eva{
+	name = "Command EVA"
+	})
 "nGW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -19647,8 +20997,11 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "nJT" = (
-/obj/structure/door_assembly/door_assembly_mhatch,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/door_assembly/door_assembly_research,
 /turf/open/floor/plasteel/airless/dark,
 /area/science/research/abandoned)
 "nKf" = (
@@ -19697,7 +21050,7 @@
 /obj/item/storage/toolbox/emergency,
 /obj/item/crowbar/red,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/mineral/plastitanium/airless,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "nKH" = (
 /obj/machinery/power/terminal{
@@ -19798,7 +21151,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/derelict/storage/equipment)
 "nTy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19896,6 +21249,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/bridge/showroom/corporate)
 "nWH" = (
@@ -19940,9 +21299,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/mine/eva{
@@ -20028,7 +21392,7 @@
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/singularity_engine)
 "ocT" = (
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "panelscorched"
 	},
 /area/ruin/space/derelict/singularity_engine)
@@ -20077,7 +21441,7 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "ofi" = (
 /obj/structure/grille,
@@ -20129,11 +21493,11 @@
 	},
 /area/ruin/space/derelict/hallway/primary/port)
 "oiV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/tcommsat/server)
 "ojn" = (
@@ -20155,7 +21519,7 @@
 /area/medical/abandoned)
 "ojD" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/crew_quarters/cryopods)
 "ojF" = (
@@ -20182,6 +21546,12 @@
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/maintenance/department/eva)
+"ojS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/hallway/secondary/entry)
 "okb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -20191,6 +21561,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
+"okc" = (
+/obj/structure/sign/warning/pods,
+/turf/closed/wall/r_wall,
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "okd" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -20334,6 +21708,9 @@
 	},
 /obj/structure/window/reinforced,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plasteel/airless/dark,
 /area/space/nearstation)
 "omZ" = (
@@ -20518,9 +21895,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/door/airlock/command{
-	name = "E.V.A. Storage";
-	req_access_txt = "18"
+/obj/machinery/door/poddoor/shutters{
+	id = "evashutter";
+	name = "E.V.A. Storage Shutter"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
@@ -20565,6 +21942,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"osj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/preopen,
+/obj/machinery/door/window/westleft{
+	dir = 4;
+	name = "kitty door";
+	req_access_txt = "200"
+	},
+/obj/machinery/door/window/westleft{
+	name = "kitty door";
+	req_access_txt = "200"
+	},
+/turf/open/floor/engine,
+/area/ruin/space/derelict/storage/equipment)
 "osw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -20579,9 +21970,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/derelict/hallway)
+/area/ruin/space/derelict/atmospherics)
 "osB" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -20624,7 +22014,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "otL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20647,6 +22037,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark/airless,
 /area/medical/chemistry)
 "ouK" = (
@@ -20734,7 +22125,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/derelict/hallway)
@@ -20890,7 +22281,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "oDZ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -21080,6 +22471,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
+"oKL" = (
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'BOMB RANGE";
+	name = "BOMB RANGE"
+	},
+/turf/closed/wall,
+/area/science/test_area)
 "oLb" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -21291,7 +22689,7 @@
 "oSa" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
@@ -21336,7 +22734,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/mineral/plastitanium/airless,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "oUz" = (
 /obj/effect/decal/remains/human,
@@ -21354,15 +22752,19 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/medical/chemistry)
 "oVd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/end,
-/obj/machinery/suit_storage_unit/open,
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel,
 /area/maintenance/department/eva)
 "oVx" = (
@@ -21370,6 +22772,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
 /turf/open/floor/carpet/royalblue,
 /area/bridge/meeting_room/council)
@@ -21434,7 +22842,7 @@
 /area/ruin/space/derelict/bridge)
 "oXn" = (
 /turf/closed/wall,
-/area/mine/unexplored)
+/area/ruin/space/derelict/atmospherics)
 "oYf" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -21710,6 +23118,13 @@
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/crew_quarters/fitness)
+"phG" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "phT" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -21735,11 +23150,11 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
@@ -21781,6 +23196,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark/airless,
 /area/crew_quarters/fitness)
 "pka" = (
@@ -21844,6 +23261,20 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"plO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/crew_quarters/fitness)
 "pmL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -21981,12 +23412,21 @@
 /obj/item/circuitboard/computer/communications,
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/bridge)
+"pqT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating/airless{
+	icon_state = "panelscorched"
+	},
+/area/science/test_area)
 "psv" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/sign/warning/vacuum,
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/obj/structure/sign/warning/vacuum,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "psR" = (
@@ -22003,7 +23443,7 @@
 /area/quartermaster/storage)
 "ptq" = (
 /obj/machinery/door/airlock/external,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/derelict/storage/equipment)
 "ptK" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -22022,6 +23462,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"pux" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/ripped,
+/turf/closed/wall,
+/area/crew_quarters/dorms)
 "pvE" = (
 /obj/machinery/telecomms/processor/preset_two,
 /obj/effect/decal/cleanable/dirt,
@@ -22054,12 +23499,37 @@
 	},
 /area/ruin/space/derelict/hallway/primary/port)
 "pxb" = (
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/singularity_engine)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/plasteel/dark/airless,
+/area/medical/chemistry)
 "pxE" = (
 /turf/closed/wall,
 /area/security/brig)
+"pyl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/derelict/hallway)
 "pym" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow{
@@ -22094,6 +23564,14 @@
 /obj/machinery/light/small,
 /turf/open/floor/engine,
 /area/science/lab)
+"pAi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/science/research/abandoned)
 "pAp" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -22128,10 +23606,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/door/airlock/command{
-	name = "E.V.A. Storage";
-	req_access_txt = "18"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
@@ -22140,6 +23614,10 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "evashutter";
+	name = "E.V.A. Storage Shutter"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
@@ -22446,9 +23924,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "pKk" = (
@@ -22516,6 +23991,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/stairs/left,
 /area/library)
+"pLp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "pLu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -22686,6 +24170,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "pSA" = (
@@ -22769,7 +24256,7 @@
 "pTJ" = (
 /obj/effect/decal/cleanable/ash,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
@@ -22812,10 +24299,35 @@
 /area/security/brig)
 "pUI" = (
 /obj/structure/grille/broken,
+/obj/machinery/atmospherics/components/binary/pump/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
 /area/medical/chemistry)
+"pVk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/weightmachine/weightlifter,
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/crew_quarters/fitness)
+"pVt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/crew_quarters/dorms)
 "pVH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/east{
@@ -22895,7 +24407,7 @@
 	dir = 1
 	},
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "pYn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22905,7 +24417,7 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
 "pYo" = (
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "platingdmg2"
 	},
 /area/hydroponics/garden/abandoned)
@@ -22918,6 +24430,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
 "pZs" = (
@@ -22958,6 +24472,26 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/gravity_generator)
+"qaD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/medical/chemistry)
 "qaI" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/chair,
@@ -22992,11 +24526,17 @@
 /area/engine/engineering)
 "qaV" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/multitool,
+/obj/item/storage/belt/utility,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "qaX" = (
@@ -23024,7 +24564,7 @@
 /obj/machinery/power/apc/auto_name/east{
 	start_charge = 0
 	},
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "qbq" = (
 /obj/structure/lattice,
@@ -23100,8 +24640,10 @@
 /area/engine/atmos)
 "qfu" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/remains/human,
-/turf/open/floor/plasteel/dark/airless,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "qfY" = (
 /obj/machinery/firealarm{
@@ -23165,9 +24707,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/derelict/hallway)
 "qhV" = (
@@ -23234,12 +24774,14 @@
 /area/security/prison)
 "qjJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the test chamber.";
+	dir = 1;
+	layer = 4;
+	name = "Test Chamber Telescreen";
+	network = list("toxins");
+	pixel_y = -30
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/spawner/lootdrop/armory_contraband,
 /turf/open/floor/plasteel/dark/airless,
 /area/science/research/abandoned)
 "qkl" = (
@@ -23335,7 +24877,9 @@
 "qnB" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/showroomfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/crew_quarters/cryopods)
 "qog" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -23363,8 +24907,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
-/area/science/research/abandoned)
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "qpl" = (
 /obj/structure/sign/poster/official/nanomichi_ad,
 /turf/closed/wall,
@@ -23431,6 +24979,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/bridge)
 "qrr" = (
@@ -23438,9 +24992,14 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"qsg" = (
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/space/nearstation)
 "qsp" = (
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "qsy" = (
 /turf/closed/wall,
@@ -23473,18 +25032,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
+"qtO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/closed/wall,
+/area/ruin/space/derelict/hallway)
 "qtS" = (
-/obj/machinery/light/small{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel/dark/airless,
-/area/science/research/abandoned)
+/turf/closed/wall,
+/area/security/prison)
 "quO" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -23534,9 +25093,33 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"qvG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/stack/sheet/iron,
+/obj/item/stack/sheet/iron,
+/obj/item/stack/sheet/iron,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/turf/open/floor/plasteel,
+/area/maintenance/department/eva)
 "qvL" = (
 /turf/open/floor/plating/airless,
 /area/hydroponics/garden/abandoned)
+"qwd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/crew_quarters/fitness)
 "qwj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/gibs/body,
@@ -23550,6 +25133,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark/airless,
 /area/crew_quarters/fitness)
 "qxg" = (
@@ -23620,13 +25205,21 @@
 /area/library/abandoned)
 "qzm" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable/yellow,
 /obj/machinery/light/small,
+/obj/item/tank/jetpack/carbondioxide{
+	pixel_x = -4;
+	pixel_y = 1
+	},
+/obj/item/clothing/shoes/magboots{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/structure/rack,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "qzA" = (
@@ -23646,7 +25239,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "qAj" = (
 /obj/machinery/computer/atmos_control/tank/air_tank{
@@ -23676,8 +25269,12 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/ruin/space/derelict/hallway)
+"qBT" = (
+/obj/structure/sign/departments/minsky/medical/chemistry/chemical1,
+/turf/closed/wall,
+/area/medical/chemistry)
 "qCk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -23723,6 +25320,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
 "qDn" = (
@@ -23745,7 +25344,10 @@
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/dark/airless,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "qEn" = (
 /obj/effect/turf_decal/delivery,
@@ -23757,6 +25359,11 @@
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/quartermaster/storage)
+"qEx" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/hallway/primary/port)
 "qEP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -23791,8 +25398,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "qFU" = (
@@ -23830,6 +25439,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/preopen,
 /obj/machinery/door/window/westleft{
+	name = "kitty door";
+	req_access_txt = "200"
+	},
+/obj/machinery/door/window/westleft{
+	dir = 4;
 	name = "kitty door";
 	req_access_txt = "200"
 	},
@@ -23892,6 +25506,12 @@
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/carpspawn,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/hallway/secondary/command)
 "qJH" = (
@@ -23913,10 +25533,11 @@
 /turf/open/floor/plasteel/dark/airless,
 /area/quartermaster/storage)
 "qKl" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
 	},
-/area/quartermaster/storage)
+/turf/closed/wall,
+/area/medical/chemistry)
 "qKr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/lethalshots,
@@ -24027,8 +25648,13 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "qOk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/window,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/science/research/abandoned)
+/area/security/prison)
 "qOy" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/window,
@@ -24044,6 +25670,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume,
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "qOP" = (
@@ -24140,7 +25767,7 @@
 /area/ruin/space/derelict/bridge)
 "qUe" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/tcommsat/server)
 "qUg" = (
@@ -24151,6 +25778,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/bridge)
 "qUl" = (
@@ -24180,11 +25809,13 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/derelict/hallway)
+/area/ruin/space/derelict/atmospherics)
+"qUM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine/airless,
+/area/ruin/space/derelict/storage/equipment)
 "qUP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/research{
@@ -24205,6 +25836,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"qVa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 4;
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	name = "Command blue corner"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/bridge/showroom/corporate)
 "qVe" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating/airless{
@@ -24299,7 +25949,7 @@
 	slogan_delay = 700
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "qYC" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -24332,7 +25982,7 @@
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "rbb" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -24426,6 +26076,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"rdK" = (
+/turf/closed/indestructible{
+	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
+	icon_state = "riveted";
+	name = "hyper-reinforced wall"
+	},
+/area/science/test_area)
 "rdN" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -24439,7 +26096,6 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "ree" = (
-/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -24452,7 +26108,10 @@
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/dark/airless,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "rem" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -24497,6 +26156,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/carpet/royalblue,
 /area/bridge/meeting_room/council)
@@ -24624,6 +26287,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
+"rjR" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "rkf" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -24649,8 +26318,16 @@
 "rlk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
+"rln" = (
+/turf/open/floor/plating/airless{
+	icon_state = "panelscorched"
+	},
+/area/quartermaster/storage)
 "rmj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -24748,6 +26425,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg3"
 	},
@@ -24768,6 +26449,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark/airless,
 /area/bridge/showroom/corporate)
 "roH" = (
@@ -24811,6 +26494,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark/airless,
 /area/bridge/showroom/corporate)
 "rqo" = (
@@ -24864,10 +26551,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/dark/airless,
 /area/engine/supermatter)
-"rrv" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "rrX" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -24976,6 +26659,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
+"ryn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/weightmachine/weightlifter,
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/crew_quarters/fitness)
 "rzx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue,
@@ -25040,6 +26735,14 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
+"rBo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating/airless{
+	icon_state = "panelscorched"
+	},
+/area/science/test_area)
 "rBC" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
@@ -25075,6 +26778,16 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"rCL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/airalarm{
+	dir = 2;
+	pixel_y = 22
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "rCS" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -25123,6 +26836,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"rEd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/plasteel/dark/airless,
+/area/bridge/showroom/corporate)
 "rEB" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -25193,8 +26911,13 @@
 /area/ai_monitored/turret_protected/ai)
 "rFV" = (
 /obj/effect/decal/remains/human,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
+"rGt" = (
+/turf/open/floor/plating/airless{
+	icon_state = "panelscorched"
+	},
+/area/science/test_area)
 "rGx" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -25226,6 +26949,13 @@
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/quartermaster/storage)
+"rGK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/medical/chemistry)
 "rHt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/gun/energy/disabler,
@@ -25450,9 +27180,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/derelict/hallway)
+/area/ruin/space/derelict/atmospherics)
 "rNw" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -25464,6 +27193,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"rNL" = (
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/deepstorage/power)
 "rOo" = (
 /obj/machinery/door/airlock/external{
 	name = "Cryo Airlock"
@@ -25496,6 +27229,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
+"rPw" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/mine/eva{
+	name = "Command EVA"
+	})
 "rQn" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -25548,6 +27289,9 @@
 /obj/item/storage/box/stockparts,
 /obj/item/storage/box/monkeycubes,
 /obj/effect/spawner/lootdrop/maintenance/eight,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "rQF" = (
@@ -25703,6 +27447,12 @@
 	icon_state = "platingdmg1"
 	},
 /area/ruin/space/has_grav/derelictoutpost/cargobay)
+"rVK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/hydroponics/garden/abandoned)
 "rWm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -25735,7 +27485,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/library/abandoned)
 "rWU" = (
 /obj/machinery/computer/shuttle,
@@ -25760,6 +27510,12 @@
 	dir = 8
 	},
 /obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/crew_quarters/dorms)
 "rYm" = (
@@ -25872,9 +27628,29 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"sba" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/medical/chemistry)
 "sbu" = (
 /obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "sbF" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -25913,10 +27689,20 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/bridge)
 "scq" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark/airless,
 /area/mine/eva{
 	name = "Command EVA"
@@ -25935,6 +27721,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "sdw" = (
@@ -25951,7 +27738,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark/airless,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "sdz" = (
 /obj/effect/turf_decal/tile/brown{
@@ -25981,6 +27771,16 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"sdE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/derelict/bridge)
 "sdQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
@@ -26059,7 +27859,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "sgi" = (
 /obj/effect/decal/cleanable/dirt,
@@ -26067,8 +27867,17 @@
 	dir = 8
 	},
 /mob/living/simple_animal/hostile/carp,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/wood/airless,
 /area/crew_quarters/dorms)
+"sgs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/closed/wall,
+/area/ruin/space/derelict/atmospherics)
 "sgt" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
@@ -26126,11 +27935,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/derelict/hallway)
+/area/ruin/space/derelict/atmospherics)
 "sji" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -26157,6 +27963,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark/airless,
 /area/crew_quarters/fitness)
 "skm" = (
@@ -26231,7 +28039,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -26250,21 +28057,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "slK" = (
-/obj/machinery/door/airlock/external,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/border_only/closed{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only/closed{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
-/area/hydroponics/garden/abandoned)
+/area/crew_quarters/theatre)
 "slP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/wallmed{
@@ -26299,6 +28095,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"sqg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/crew_quarters/heads/captain/private{
+	name = "Admiral's Quarters"
+	})
 "sqn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
@@ -26352,8 +28157,18 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/l3closet/virology,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
+"srH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/medical/chemistry)
 "srU" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -26398,7 +28213,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/mineral/plastitanium/airless,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "ssG" = (
 /obj/structure/cable/yellow{
@@ -26415,6 +28230,14 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"stq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblue,
+/area/bridge/meeting_room/council)
 "stz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue{
@@ -26429,6 +28252,12 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/bridge/showroom/corporate)
@@ -26526,10 +28355,13 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/deepstorage/power)
 "sxm" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/window,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
 	},
-/area/science/research/abandoned)
+/turf/open/floor/plating,
+/area/security/prison)
 "sxo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/cell_charger{
@@ -26637,6 +28469,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ruin/space/derelict/hallway)
 "sAl" = (
@@ -26690,7 +28525,8 @@
 "sBo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/green,
-/turf/open/floor/plasteel/dark/airless,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "sBw" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -26707,7 +28543,8 @@
 /area/engine/engineering)
 "sCe" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/door/firedoor/window,
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -26816,13 +28653,19 @@
 "sIl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/storage/toolbox/emergency,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/item/radio/off,
 /turf/open/floor/plasteel/dark/airless,
 /area/maintenance/department/eva)
 "sIE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+	dir = 5
 	},
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "sJh" = (
@@ -26851,7 +28694,7 @@
 /obj/item/wrench,
 /obj/item/storage/firstaid/fire,
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/derelict/hallway)
+/area/ruin/space/derelict/atmospherics)
 "sLX" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -26902,20 +28745,33 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"sNi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/derelict/bridge)
 "sNz" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
@@ -26934,8 +28790,20 @@
 	dir = 4;
 	name = "Command blue corner"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/bridge)
+"sRz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/ruin/space/derelict/hallway)
 "sRC" = (
 /obj/structure/girder,
 /turf/open/floor/plating/airless{
@@ -26973,8 +28841,11 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "sTj" = (
-/turf/open/floor/plating,
-/area/ruin/space/derelict/storage/equipment)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/medical/virology)
 "sTo" = (
 /obj/structure/lattice,
 /obj/item/stack/sheet/iron,
@@ -27115,7 +28986,6 @@
 	name = "Prison Access";
 	req_access_txt = "2"
 	},
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -27125,16 +28995,31 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark/airless,
-/area/ruin/space/derelict/arrival)
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "sYe" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
 /area/ruin/space/derelict/storage/equipment)
+"sYO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/derelict/hallway)
 "sZe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/box,
@@ -27328,6 +29213,11 @@
 	name = "kitty door";
 	req_access_txt = "200"
 	},
+/obj/machinery/door/window/westleft{
+	dir = 2;
+	name = "kitty door";
+	req_access_txt = "200"
+	},
 /turf/open/floor/engine,
 /area/ruin/space/derelict/storage/equipment)
 "teJ" = (
@@ -27349,6 +29239,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/derelict/hallway)
 "tfA" = (
@@ -27410,7 +29301,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/derelict/hallway)
+/area/ruin/space/derelict/atmospherics)
 "thL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark/airless,
@@ -27419,9 +29310,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 26
-	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "tiD" = (
@@ -27475,11 +29363,11 @@
 /area/science/lab)
 "tkN" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/light/small,
+/obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "tlo" = (
@@ -27527,6 +29415,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"tmV" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden/abandoned)
 "tmY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/on{
 	dir = 8;
@@ -27560,7 +29456,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating/airless,
 /area/ruin/space/derelict/storage/equipment)
 "tpk" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -27628,10 +29524,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/derelict/hallway)
 "tqX" = (
@@ -27700,6 +29595,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/abandoned_tele)
+"ttn" = (
+/obj/machinery/atmospherics/components/binary/pump/layer3{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/hydroponics/garden/abandoned)
 "ttz" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -27772,15 +29673,18 @@
 /area/medical/virology)
 "tvW" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "twn" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/random{
-	pixel_y = 32
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/machinery/button/door{
+	id = "Cabin4";
+	name = "Cabin Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = -25;
+	specialfunctions = 4
 	},
 /turf/open/floor/plating/airless{
 	icon_state = "panelscorched"
@@ -27870,6 +29774,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/engine/supermatter)
+"tBI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/derelict/bridge)
 "tBR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
@@ -27928,7 +29839,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark/airless,
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/crew_quarters/theatre)
 "tDR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -27939,12 +29854,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/storage/equipment)
-"tDS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
-/area/ruin/space/has_grav/derelictoutpost/dockedship)
 "tDU" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -27968,10 +29877,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark/airless,
 /area/library/abandoned)
-"tEo" = (
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/ruin/space/derelict/gravity_generator)
 "tFt" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -27987,7 +29892,7 @@
 	dir = 8
 	},
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "tFV" = (
 /turf/open/floor/plasteel/dark,
@@ -28027,6 +29932,18 @@
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/bridge)
+"tHl" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/exit)
 "tHC" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -28043,7 +29960,9 @@
 /area/medical/virology)
 "tHW" = (
 /obj/structure/girder,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
 /area/quartermaster/storage)
 "tIq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -28228,6 +30147,7 @@
 	icon_state = "0-2"
 	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "tQg" = (
@@ -28340,6 +30260,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/carpet/royalblue,
 /area/bridge/meeting_room/council)
@@ -28487,7 +30413,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "tVN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -28503,7 +30429,12 @@
 "tWL" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/carp,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/showroomfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/crew_quarters/cryopods)
 "tWU" = (
 /obj/effect/turf_decal/tile/bar{
@@ -28793,13 +30724,19 @@
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/library/abandoned)
+"udN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/closed/wall,
+/area/ruin/space/derelict/hallway)
 "ueQ" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/library/abandoned)
 "ufq" = (
 /obj/effect/turf_decal/tile/brown{
@@ -28871,7 +30808,10 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark/airless,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "uie" = (
 /obj/effect/decal/cleanable/dirt,
@@ -28964,10 +30904,11 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "unC" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/area/science/research/abandoned)
+/turf/closed/wall/r_wall,
+/area/medical/virology)
 "unP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -29062,7 +31003,7 @@
 /obj/effect/turf_decal/tile/green,
 /obj/machinery/hydroponics/constructable,
 /obj/item/seeds/carrot,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "uqt" = (
 /obj/effect/decal/cleanable/dirt,
@@ -29081,12 +31022,13 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/item/reagent_containers/glass/bucket,
 /obj/structure/sign/poster/random{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/dark/airless,
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "uqI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -29159,8 +31101,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/ai_monitored/security/armory)
@@ -29200,7 +31145,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/derelict/hallway)
+/area/ruin/space/derelict/atmospherics)
 "uvx" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -29228,7 +31173,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "uwU" = (
 /turf/closed/wall,
@@ -29304,6 +31249,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/bridge)
 "uAr" = (
@@ -29351,9 +31302,11 @@
 "uBD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/end,
-/obj/machinery/suit_storage_unit/open,
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/structure/closet/crate/rcd{
+	pixel_y = 4
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/eva)
@@ -29408,6 +31361,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "uFb" = (
@@ -29451,7 +31407,7 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/derelict/hallway)
+/area/ruin/space/derelict/atmospherics)
 "uGh" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -29486,6 +31442,12 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/bridge/showroom/corporate)
@@ -29561,7 +31523,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/library/abandoned)
 "uKA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -29572,6 +31534,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark/airless,
 /area/crew_quarters/fitness)
 "uKB" = (
@@ -29641,7 +31605,7 @@
 	},
 /obj/machinery/hydroponics/constructable,
 /obj/item/seeds/ambrosia/deus,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "uON" = (
 /obj/machinery/computer/monitor{
@@ -29781,6 +31745,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/bridge)
 "uTk" = (
@@ -29838,12 +31808,6 @@
 "uVx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/derelict/hallway)
 "uWg" = (
@@ -29886,20 +31850,20 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "uZa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/frame/computer{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/science/research/abandoned)
 "uZf" = (
@@ -29910,6 +31874,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark/airless,
 /area/medical/abandoned)
+"uZt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
+/area/ruin/space/derelict/atmospherics)
 "uZx" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/layer3{
 	on = 1
@@ -30025,7 +31993,7 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "vdS" = (
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "platingdmg3"
 	},
 /area/ruin/space/derelict/gravity_generator)
@@ -30037,9 +32005,8 @@
 /turf/open/floor/plasteel/dark/airless,
 /area/science/research/abandoned)
 "veb" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/layer3{
-	dir = 1;
-	on = 1
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3{
+	dir = 1
 	},
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg3"
@@ -30210,6 +32177,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/bridge/meeting_room/council)
 "vks" = (
@@ -30222,6 +32195,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/medical/chemistry)
@@ -30301,20 +32280,11 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "voK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark/airless,
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume,
+/turf/open/floor/plating,
 /area/crew_quarters/theatre)
 "vpj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -30370,6 +32340,13 @@
 	},
 /turf/open/space/basic,
 /area/science/research/abandoned)
+"vro" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/plasteel/dark/airless,
+/area/crew_quarters/heads/captain/private{
+	name = "Admiral's Quarters"
+	})
 "vrP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -30386,6 +32363,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/hallway/secondary/command)
 "vsl" = (
@@ -30395,6 +32378,12 @@
 "vsr" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump{
+	dir = 1
+	},
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
 	},
 /turf/open/floor/plating/airless{
 	icon_state = "panelscorched"
@@ -30466,6 +32455,13 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/storage/equipment)
+"vvz" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "vwF" = (
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
@@ -30485,7 +32481,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/derelict/hallway)
 "vxA" = (
@@ -30594,6 +32592,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "vAf" = (
@@ -30604,7 +32605,7 @@
 /obj/effect/turf_decal/tile/green,
 /obj/machinery/hydroponics/constructable,
 /obj/item/seeds/wheat,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "vAg" = (
 /obj/effect/decal/cleanable/dirt,
@@ -30760,13 +32761,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
-"vET" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/supermatter)
 "vFK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue{
@@ -30798,6 +32792,12 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/crew_quarters/fitness)
 "vHN" = (
@@ -30813,7 +32813,7 @@
 	dir = 4
 	},
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "vHR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -30882,10 +32882,20 @@
 /area/library/abandoned)
 "vIF" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/rack,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/plasteel{
+	amount = 10
+	},
+/obj/item/stack/sheet/plasteel{
+	amount = 10
+	},
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "vIS" = (
@@ -30903,6 +32913,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/fore/secondary)
+"vJL" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "vJW" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -31017,6 +33033,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"vNj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/crew_quarters/fitness)
 "vNM" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/airless,
@@ -31042,9 +33069,6 @@
 /area/bridge)
 "vPB" = (
 /obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -31056,7 +33080,10 @@
 	dir = 1
 	},
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/dark/airless,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "vPI" = (
 /obj/effect/turf_decal/tile/purple,
@@ -31093,11 +33120,14 @@
 /area/ruin/space/has_grav/deepstorage/power)
 "vQY" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "vRn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/wood/airless,
@@ -31167,6 +33197,11 @@
 /obj/machinery/computer/scan_consolenew,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
+"vVs" = (
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/science/test_area)
 "vVK" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -31285,6 +33320,12 @@
 /obj/machinery/door/airlock/vault{
 	req_access_txt = "19"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/bridge)
 "vYe" = (
@@ -31354,11 +33395,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/derelict/hallway)
+/area/ruin/space/derelict/atmospherics)
 "waq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow{
@@ -31367,16 +33405,11 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/derelict/hallway)
+/area/ruin/space/derelict/atmospherics)
 "waC" = (
 /obj/structure/girder,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/turf/open/floor/plating/airless,
 /area/ruin/space/derelict/gravity_generator)
 "waR" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -31388,6 +33421,12 @@
 /obj/item/book/manual/chef_recipes,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
+"waV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/closed/wall,
+/area/ruin/space/derelict/hallway)
 "wbf" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -31483,6 +33522,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/dark/airless,
 /area/mine/eva{
 	name = "Command EVA"
@@ -31545,11 +33585,6 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
-"wfA" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/hydroponics/garden/abandoned)
 "wfF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced{
@@ -31686,7 +33721,9 @@
 	dir = 2;
 	pixel_y = 22
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/showroomfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/crew_quarters/cryopods)
 "wlQ" = (
 /turf/open/floor/plating/airless,
@@ -31741,6 +33778,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "wnY" = (
@@ -31785,6 +33823,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark/airless,
 /area/library/abandoned)
+"wpk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/window,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/mine/eva{
+	name = "Command EVA"
+	})
 "wpN" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -31829,7 +33877,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "wqN" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
@@ -31837,8 +33885,10 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "wqU" = (
-/obj/structure/grille,
-/turf/open/floor/plasteel/dark/airless,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/closed/wall,
 /area/crew_quarters/theatre)
 "wqV" = (
 /obj/structure/cable/yellow{
@@ -31868,7 +33918,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/mineral/plastitanium/airless,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "wrF" = (
 /obj/structure/sign/warning/securearea{
@@ -31941,9 +33991,25 @@
 "wtv" = (
 /turf/closed/wall,
 /area/ruin/space/derelict/gravity_generator)
+"wtU" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/departments/minsky/engineering/atmospherics{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/deepstorage/power)
 "wuc" = (
 /obj/machinery/light/small,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/derelict/storage/equipment)
 "wul" = (
 /obj/machinery/power/solar{
@@ -31961,7 +34027,7 @@
 	dir = 8
 	},
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "wuF" = (
 /obj/effect/turf_decal/tile/red{
@@ -32046,7 +34112,9 @@
 /obj/structure/sign/poster/random{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/showroomfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/crew_quarters/cryopods)
 "wwz" = (
 /obj/effect/turf_decal/tile/red,
@@ -32071,8 +34139,8 @@
 /obj/structure/frame/computer{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/airless,
@@ -32096,16 +34164,22 @@
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "wyg" = (
-/obj/machinery/door/firedoor/border_only/closed,
-/obj/machinery/door/firedoor/border_only/closed{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
@@ -32155,7 +34229,9 @@
 /obj/structure/sign/poster/random{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/showroomfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/crew_quarters/cryopods)
 "wBR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -32222,7 +34298,8 @@
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
-/obj/machinery/suit_storage_unit/standard_unit,
+/obj/structure/closet/toolcloset,
+/obj/item/clothing/gloves/color/yellow,
 /turf/open/floor/plasteel,
 /area/maintenance/department/eva)
 "wET" = (
@@ -32261,6 +34338,12 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/ruin/space/derelict/bridge)
 "wGd" = (
@@ -32294,6 +34377,12 @@
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/library/abandoned)
+"wGy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel/dark/airless,
+/area/medical/chemistry)
 "wGL" = (
 /obj/machinery/door/airlock,
 /obj/effect/turf_decal/stripes/line,
@@ -32317,6 +34406,9 @@
 /area/crew_quarters/heads/captain/private{
 	name = "Admiral's Quarters"
 	})
+"wHx" = (
+/turf/closed/wall,
+/area/science/test_area)
 "wHC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -32340,7 +34432,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
 "wIw" = (
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "panelscorched"
 	},
 /area/ruin/space/derelict/gravity_generator)
@@ -32349,14 +34441,32 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark/airless,
 /area/bridge/showroom/corporate)
+"wKT" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/window,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/medical/virology)
 "wLJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"wMd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel/dark/airless,
+/area/bridge/showroom/corporate)
 "wMs" = (
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 8
@@ -32424,15 +34534,14 @@
 	},
 /obj/machinery/hydroponics/constructable,
 /obj/item/seeds/ambrosia/gaia,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "wNV" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/supermatter)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/ruin/space/derelict/storage/equipment)
 "wOb" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -32449,10 +34558,22 @@
 "wOL" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"wPj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/turf/closed/wall,
+/area/quartermaster/miningdock)
 "wPQ" = (
 /obj/structure/grille/broken,
 /turf/open/space/basic,
 /area/space)
+"wPV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/closed/wall,
+/area/ruin/space/derelict/hallway)
 "wQe" = (
 /obj/structure/window/shuttle,
 /obj/structure/grille,
@@ -32490,6 +34611,19 @@
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/library/abandoned)
+"wRo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/derelict/hallway)
 "wRp" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -32589,7 +34723,7 @@
 	name = "Custodial Supplies";
 	req_access_txt = "201"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/derelict/storage/equipment)
 "wTD" = (
 /obj/effect/decal/cleanable/dirt,
@@ -32597,14 +34731,12 @@
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/storage/equipment)
 "wUf" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/advanced_airlock_controller{
+	dir = 4;
+	pixel_x = -24
 	},
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
-/area/science/research/abandoned)
+/area/hallway/secondary/exit)
 "wUu" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "HoP Maintenance";
@@ -32622,7 +34754,7 @@
 "wUv" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/killertomato,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "wVl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -32651,8 +34783,8 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "wVX" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
 	},
 /area/hydroponics/garden/abandoned)
 "wWb" = (
@@ -32681,6 +34813,12 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/medical/chemistry)
@@ -32721,7 +34859,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/ruin/space/derelict/hallway)
 "wXF" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -32876,6 +35014,9 @@
 	dir = 4;
 	name = "Command blue corner"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/mine/eva{
 	name = "Command EVA"
@@ -33004,6 +35145,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on/layer3{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "xfy" = (
@@ -33042,6 +35184,13 @@
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/storage/equipment)
+"xgf" = (
+/obj/structure/lattice,
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_x = 32
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "xgu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark/airless,
@@ -33116,7 +35265,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "xhr" = (
 /obj/structure/lattice,
@@ -33131,16 +35280,14 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "xiC" = (
 /obj/structure/girder,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/plating/airless,
 /area/quartermaster/storage)
 "xiI" = (
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/derelict/gravity_generator)
 "xje" = (
 /obj/structure/lattice,
@@ -33155,7 +35302,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "xkt" = (
 /obj/effect/decal/cleanable/dirt,
@@ -33178,7 +35325,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "xlz" = (
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "panelscorched"
 	},
 /area/hydroponics/garden/abandoned)
@@ -33209,6 +35356,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood/gibs/body,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "xnL" = (
@@ -33242,7 +35392,10 @@
 /obj/machinery/hydroponics/constructable,
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/seeds/wheat,
-/turf/open/floor/plasteel/dark/airless,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "xoS" = (
 /obj/structure/flora/ausbushes/grassybush,
@@ -33385,7 +35538,6 @@
 	name = "Prison Access";
 	req_access_txt = "2"
 	},
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -33395,8 +35547,14 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark/airless,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
+"xtE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 8
+	},
+/turf/closed/wall,
+/area/ruin/space/derelict/hallway)
 "xtI" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -33458,6 +35616,16 @@
 "xva" = (
 /turf/closed/wall,
 /area/hydroponics)
+"xvn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/machinery/camera/preset/toxins{
+	dir = 1
+	},
+/obj/item/target,
+/turf/open/floor/plating/airless,
+/area/science/test_area)
 "xvr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral,
@@ -33475,8 +35643,17 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating/airless,
 /area/ruin/space/derelict/storage/equipment)
+"xvY" = (
+/obj/structure/lattice,
+/obj/structure/sign/directions/security{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "xwL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/seed_extractor,
@@ -33496,6 +35673,8 @@
 	start_charge = 0
 	},
 /obj/structure/cable/yellow,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark/airless,
 /area/crew_quarters/dorms)
 "xxu" = (
@@ -33516,10 +35695,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/derelict/hallway)
 "xyO" = (
@@ -33591,6 +35770,19 @@
 "xAV" = (
 /turf/closed/wall,
 /area/hallway/secondary/exit)
+"xCZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/ai_upload_foyer";
+	name = "AI Upload Access APC";
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "xDa" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -33651,6 +35843,8 @@
 	},
 /obj/item/paper_bin,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
 "xEB" = (
@@ -33691,15 +35885,23 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/arrival)
 "xFh" = (
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
 	},
-/area/space/nearstation)
+/turf/closed/wall,
+/area/medical/chemistry)
 "xFp" = (
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
 /area/quartermaster/storage)
+"xFI" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "xHq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue,
@@ -33717,6 +35919,12 @@
 	icon_state = "medium"
 	},
 /obj/effect/decal/cleanable/glass,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/bridge/showroom/corporate)
 "xHz" = (
@@ -33759,7 +35967,7 @@
 /area/ruin/space/derelict/hallway/primary/port)
 "xJj" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "platingdmg3"
 	},
 /area/ruin/space/derelict/singularity_engine)
@@ -33787,14 +35995,12 @@
 	pixel_y = -7
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
 	pixel_y = -27
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -33890,6 +36096,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/bridge)
 "xMg" = (
@@ -33903,6 +36115,12 @@
 	color = "#4169E1";
 	dir = 8;
 	name = "Command blue corner"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/mine/eva{
@@ -33968,9 +36186,22 @@
 	name = "Admiral's Quarters"
 	})
 "xOp" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/library/abandoned)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/medical/chemistry)
 "xOJ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -34051,6 +36282,16 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark/airless,
 /area/library/abandoned)
+"xRb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/derelict/bridge)
 "xRt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/loading_area{
@@ -34207,6 +36448,16 @@
 	},
 /turf/open/floor/plating/airless,
 /area/medical/chemistry)
+"xVv" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/window,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/mine/eva{
+	name = "Command EVA"
+	})
 "xVy" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/decal/cleanable/dirt,
@@ -34230,7 +36481,10 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark/airless,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden/abandoned)
 "xWl" = (
 /obj/structure/closet/firecloset,
@@ -34340,6 +36594,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
+"yac" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/science/test_area)
 "yat" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -34504,14 +36765,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/derelict/hallway)
@@ -34547,7 +36805,9 @@
 /obj/item/storage/firstaid/regular,
 /obj/item/crowbar,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/showroomfloor{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/crew_quarters/cryopods)
 "yhC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -34618,7 +36878,7 @@
 /area/tcommsat/server)
 "ykp" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "panelscorched"
 	},
 /area/ruin/space/derelict/singularity_engine)
@@ -46875,10 +49135,10 @@ aBg
 aBg
 aBg
 qgt
-qgt
-pqo
-ecE
-rfm
+geX
+geX
+fhN
+hwl
 qgt
 qgt
 aBg
@@ -47131,13 +49391,13 @@ aBg
 aBg
 aBg
 qgt
-ecE
-whH
-nil
+sGB
+azK
+qsg
 mmS
-pqo
+wOL
 qgt
-pqo
+wOL
 qgt
 aBg
 aBg
@@ -47387,14 +49647,14 @@ aBg
 aBg
 aBg
 aBg
-nFs
-nFs
-nFs
-nFs
-nFs
-nFs
-nFs
-nFs
+cjO
+qgt
+vJL
+rjR
+vJL
+rjR
+wOg
+cjO
 qgt
 qgt
 aBg
@@ -47644,15 +49904,15 @@ aBg
 aBg
 aBg
 aBg
-nFs
-vET
+cjO
+wOg
 etk
-vET
 etk
-vET
 etk
-nFs
-pqo
+etk
+qgt
+cjO
+wOL
 qgt
 aBg
 aBg
@@ -47901,15 +50161,15 @@ aBg
 aBg
 aBg
 aBg
-nFs
-wNV
-nFM
-aUA
-nFM
-aUA
-wNV
-nFs
-whH
+cjO
+wOg
+etk
+etk
+etk
+etk
+qgt
+wPQ
+azK
 qgt
 aBg
 aBg
@@ -48158,15 +50418,15 @@ aBg
 aBg
 aBg
 aBg
-nFs
-nFM
+cjO
+qgt
 etk
-fNM
-fNM
-vET
-aUA
-nFs
-pqo
+etk
+etk
+etk
+qgt
+cjO
+wOL
 kqG
 qgt
 qgt
@@ -48415,16 +50675,16 @@ aBg
 aBg
 aBg
 aBg
-nFs
-fNM
+qgt
+qgt
 dcn
-fNM
-fNM
+fks
+vvz
 dcn
-fNM
-nFs
-nil
-pqo
+qgt
+cjO
+qsg
+wOL
 qgt
 qgt
 qgt
@@ -48906,7 +51166,7 @@ aBg
 aBg
 qgt
 aBg
-bsN
+wOL
 aBg
 aBg
 qgt
@@ -49693,7 +51953,7 @@ sTo
 qgt
 qgt
 qgt
-bsN
+wOL
 aBg
 aBg
 aBg
@@ -50718,7 +52978,7 @@ jQW
 jYH
 dZs
 jQW
-auN
+cKe
 dZs
 jQW
 gQi
@@ -50957,7 +53217,7 @@ qgt
 nwk
 wlM
 qnB
-ccu
+dUN
 ccu
 cCs
 cCs
@@ -50994,10 +53254,10 @@ tBr
 vfR
 tSb
 rSF
-nFs
+bHM
 eOo
 nLK
-ptk
+rNL
 ptk
 aBg
 aBg
@@ -51229,10 +53489,10 @@ udw
 wuF
 cCs
 akB
-efW
+lsW
 oGM
 efW
-efW
+lsW
 oGM
 efW
 iRa
@@ -51471,27 +53731,27 @@ qgt
 nwk
 hVq
 eSt
-eSt
-eSt
+ayK
+lsM
 mdf
 sjQ
 geG
-geG
-geG
+dqe
+aWZ
 qwX
-geG
-geG
-geG
-qwX
+nom
+aWZ
+aWZ
+gyn
 kAd
 dZV
 bkL
 gpy
-gpy
-gpy
+mgs
+mgs
 gpy
 nFf
-gpy
+mgs
 xxo
 vxd
 qgt
@@ -51722,7 +53982,7 @@ aBg
 aBg
 aBg
 aBg
-bsN
+wOL
 qgt
 sTo
 nwk
@@ -51743,10 +54003,10 @@ dwZ
 rCS
 cCs
 nnV
-ucR
+cEI
 kMn
 ucR
-ucR
+cEI
 kMn
 ucR
 rXf
@@ -52250,20 +54510,20 @@ sSr
 sSr
 sSr
 mGn
-sSr
+lJV
 sSr
 sSr
 jAF
 cCs
 dZs
-jQW
-auN
-dZs
-jQW
+jBF
+eZR
+pux
+gmV
 lIV
-dZs
+pux
 twn
-xkt
+mVD
 vxd
 qgt
 aBg
@@ -52502,25 +54762,25 @@ aBg
 cCs
 pCo
 uAy
-uAy
+qwd
 sJh
 uAy
 drG
 nKk
-sJh
+ryn
 uAy
 drG
 iQa
 cCs
 dZs
-mVY
+auN
 lLx
 dZs
 xkt
 qgt
 uZM
 qgt
-qgt
+xFI
 aBg
 qgt
 aBg
@@ -52759,19 +55019,19 @@ aBg
 qgt
 rYH
 ouK
-uAy
+mUU
 sJh
 uAy
 drG
 nKk
-sJh
-uAy
-drG
-iQa
+pVk
+gLD
+mlt
+vNj
 cCs
 vxd
 boF
-xkt
+pVt
 qgt
 eBY
 aBg
@@ -53021,7 +55281,7 @@ glS
 uKA
 uKA
 pjB
-xdC
+plO
 xdC
 xdC
 cwg
@@ -53822,7 +56082,7 @@ cbb
 pqo
 whH
 ptk
-eOo
+wtU
 nLK
 kUq
 uaR
@@ -54048,7 +56308,7 @@ aBg
 aBg
 aBg
 qgt
-wIw
+xiI
 wtv
 wtv
 qgt
@@ -54278,7 +56538,7 @@ lYR
 fjr
 vyY
 rWm
-nKK
+mVY
 whf
 xEB
 wwD
@@ -54304,7 +56564,7 @@ aBg
 aBg
 xiI
 qgt
-tEo
+waC
 xiI
 xiI
 wtv
@@ -54535,7 +56795,7 @@ guF
 iyY
 dxM
 lAJ
-dxM
+nFM
 qhV
 vXN
 nvE
@@ -54790,9 +57050,9 @@ qjw
 qjw
 qjw
 qjw
-guF
+dje
 xtA
-guF
+qtS
 qjw
 qjw
 qjw
@@ -54818,7 +57078,7 @@ aBg
 qgt
 qgt
 wtv
-wIw
+xiI
 tCh
 lTD
 ftR
@@ -55046,16 +57306,16 @@ aBg
 aBg
 qgt
 qgt
-tYc
-vVU
+bsN
+ecE
 gVX
-vVU
-tYc
-tap
-hFz
-tap
+qOk
+bsN
+bsN
+vXB
+bsN
 qjw
-tap
+bsN
 qgt
 qgt
 qgt
@@ -55067,7 +57327,7 @@ aBg
 aBg
 aBg
 qgt
-qgt
+xgf
 qgt
 qgt
 qgt
@@ -55303,11 +57563,11 @@ aBg
 aBg
 aBg
 qgt
-tYc
-vVU
-cLN
-vVU
-tYc
+bsN
+qjw
+ehk
+qOk
+bsN
 qgt
 qgt
 aBg
@@ -55560,11 +57820,11 @@ aBg
 aBg
 aBg
 qgt
-tYc
-vVU
-pcJ
-vVU
-kmo
+bsN
+qjw
+iOc
+sxm
+vXB
 agv
 tYc
 agv
@@ -55618,7 +57878,7 @@ oMg
 kYM
 wEw
 mqJ
-gEx
+jGz
 oVd
 oMg
 qgt
@@ -55817,24 +58077,24 @@ aBg
 aBg
 aBg
 aBg
-tYc
-vVU
-sXL
-agv
-agv
-agv
-agv
-agv
-lOn
-lOn
-lOn
-lOn
-agv
-agv
-agv
-qgt
-qgt
 bsN
+qjw
+sXL
+qjw
+agv
+agv
+agv
+agv
+lOn
+lOn
+lOn
+lOn
+agv
+agv
+agv
+qgt
+qgt
+wOL
 qgt
 fKL
 cze
@@ -56074,7 +58334,7 @@ aBg
 aBg
 aBg
 aBg
-kmo
+vXB
 aLi
 yat
 xSO
@@ -56389,7 +58649,7 @@ oMg
 hPo
 vUS
 sIl
-sIl
+diw
 pWP
 hTi
 aBg
@@ -56643,10 +58903,10 @@ aBg
 qgt
 aBg
 oMg
-cYT
+hPo
 vUS
-sIl
-sIl
+ckm
+ayY
 pWP
 hTi
 aBg
@@ -56666,13 +58926,13 @@ xJh
 xdV
 xdV
 xdV
-xJh
+qEx
 iSS
 iSS
-xJh
+qEx
 xdV
-xJh
-xJh
+qEx
+qEx
 xdV
 xdV
 xdV
@@ -56852,10 +59112,10 @@ vVU
 tYc
 sTo
 aBg
-eEg
+faA
 lOu
 qOI
-eEg
+sTj
 jeD
 jeD
 jeD
@@ -57109,10 +59369,10 @@ vVU
 kmo
 qgt
 eEg
-eEg
+osD
 cEu
 hVe
-eEg
+unC
 eEg
 dwa
 dwa
@@ -57167,7 +59427,7 @@ gbs
 aBg
 aBg
 mjd
-tDS
+vQY
 pTJ
 xht
 oeR
@@ -57369,7 +59629,7 @@ eEg
 kpj
 omg
 gjX
-dwa
+wKT
 gxS
 bFp
 bFp
@@ -57417,7 +59677,7 @@ oMg
 aHP
 mlO
 gEx
-gEx
+qvG
 uBD
 oMg
 gbs
@@ -57435,7 +59695,7 @@ aBg
 aBg
 aBg
 qgt
-xJh
+qEx
 eZe
 jdd
 jdd
@@ -57444,7 +59704,7 @@ jdd
 jdd
 jdd
 wiw
-xJh
+qEx
 aBg
 aBg
 qgt
@@ -57616,7 +59876,7 @@ aBg
 aBg
 aBg
 qgt
-kmo
+vXB
 vVU
 cLN
 vVU
@@ -57676,7 +59936,7 @@ jwy
 oMg
 jwy
 oMg
-oMg
+bUF
 azo
 aBg
 aBg
@@ -57692,7 +59952,7 @@ aBg
 aBg
 aBg
 aBg
-xJh
+qEx
 eZe
 jdd
 jdd
@@ -57701,7 +59961,7 @@ jdd
 jdd
 jdd
 nWL
-xJh
+qEx
 qgt
 aBg
 aBg
@@ -57873,7 +60133,7 @@ aBg
 aBg
 aBg
 aBg
-kmo
+vXB
 vVU
 ffY
 aLi
@@ -57891,7 +60151,7 @@ jLX
 dwa
 aBg
 aBg
-bsN
+wOL
 qgt
 xUz
 xUz
@@ -57909,7 +60169,7 @@ wtv
 wtv
 wtv
 wtv
-aBg
+iKH
 aBg
 aBg
 aBg
@@ -57949,7 +60209,7 @@ aBg
 aBg
 aBg
 aBg
-xJh
+qEx
 mkw
 tok
 mkw
@@ -57958,7 +60218,7 @@ mkw
 tok
 mkw
 tok
-xJh
+qEx
 qgt
 aBg
 aBg
@@ -58170,7 +60430,7 @@ qgt
 aBg
 aBg
 aBg
-rrv
+tvW
 fEX
 tvW
 aBg
@@ -58427,7 +60687,7 @@ qgt
 aBg
 aBg
 aBg
-rrv
+ojS
 fKu
 sIE
 aBg
@@ -58464,14 +60724,14 @@ aBg
 qgt
 aBg
 sqo
-xJh
-xJh
-xJh
+qEx
+qEx
+qEx
 sqo
 sqo
-xJh
-xJh
-xJh
+qEx
+qEx
+qEx
 sqo
 aBg
 qgt
@@ -58683,8 +60943,8 @@ kqG
 xje
 qgt
 odb
-rrv
-fBB
+tvW
+psv
 pJT
 psv
 chf
@@ -58904,7 +61164,7 @@ aBg
 aBg
 aBg
 aBg
-qgt
+xvY
 aBg
 jeD
 eEg
@@ -59161,7 +61421,7 @@ aBg
 aBg
 aBg
 aBg
-aLi
+mKc
 agv
 aBg
 eEg
@@ -59430,8 +61690,8 @@ jeD
 aBg
 aBg
 gRE
-sTj
-iOc
+lEX
+fIb
 gRE
 cjO
 qgt
@@ -60455,7 +62715,7 @@ ppN
 osD
 eEg
 qgt
-nbS
+wNV
 caK
 rIE
 fIb
@@ -60712,7 +62972,7 @@ bkR
 kKu
 eEg
 qgt
-nbS
+wNV
 caK
 fIb
 vTJ
@@ -60724,7 +62984,7 @@ mXY
 fIb
 mpn
 fIb
-sTj
+lEX
 sYe
 yfY
 yfY
@@ -60786,7 +63046,7 @@ jPR
 euh
 euh
 qgt
-erA
+aBg
 dUM
 qgt
 uwU
@@ -60969,7 +63229,7 @@ gQj
 oEX
 erm
 qgt
-nbS
+wNV
 caK
 rIE
 fIb
@@ -60981,7 +63241,7 @@ caK
 fIb
 fIb
 fIb
-sTj
+lEX
 ldW
 kqG
 qbI
@@ -61558,7 +63818,7 @@ aBg
 aBg
 aBg
 aBg
-qgt
+aBg
 qgt
 uwU
 fRe
@@ -61815,7 +64075,7 @@ aBg
 aBg
 aBg
 aBg
-qgt
+aBg
 wlQ
 uwU
 cEX
@@ -62071,8 +64331,8 @@ aBg
 aBg
 aBg
 aBg
-qOk
-qgt
+aBg
+aBg
 wlQ
 uwU
 vjY
@@ -62329,7 +64589,7 @@ aBg
 aBg
 aBg
 aBg
-sTo
+aBg
 uGn
 uwU
 wlQ
@@ -63099,8 +65359,8 @@ aBg
 aBg
 aBg
 aBg
-uGn
-qgt
+aBg
+aBg
 qgt
 uwU
 uaK
@@ -63284,8 +65544,8 @@ aBg
 qgt
 gRE
 mti
-xWU
-xWU
+cJz
+cJz
 nbS
 caK
 uaZ
@@ -63542,7 +65802,7 @@ qgt
 qgt
 qgt
 oFZ
-jFq
+qUM
 nbS
 ayX
 fIb
@@ -63799,7 +66059,7 @@ qgt
 aBg
 qgt
 lUQ
-xWU
+cJz
 hkI
 lcH
 fIb
@@ -63870,8 +66130,8 @@ aBg
 aBg
 aBg
 aBg
-qgt
-uGn
+aBg
+aBg
 wlQ
 uwU
 fRe
@@ -64383,9 +66643,9 @@ bgr
 aBg
 aBg
 aBg
-qgt
-wlQ
-oLb
+aBg
+aBg
+aBg
 aBg
 uwU
 fRe
@@ -64575,7 +66835,7 @@ mti
 nbS
 qHa
 mti
-qHa
+osj
 nbS
 mti
 jFq
@@ -64639,8 +66899,8 @@ aBg
 aBg
 aBg
 aBg
-qgt
-wlQ
+aBg
+aBg
 meg
 oDH
 aBg
@@ -65911,10 +68171,10 @@ xAV
 tBg
 vaM
 cBc
-cBc
+aNC
 knM
-bOK
-xAV
+gXv
+qSO
 aBg
 qgt
 uwU
@@ -66113,8 +68373,8 @@ aBg
 qgt
 qgt
 qgt
-ddC
-ddC
+nDU
+nDU
 bcO
 qgt
 qgt
@@ -66168,10 +68428,10 @@ xAV
 aNt
 vaM
 iya
-cBc
+jvm
 aDH
-cBc
-xAV
+iqg
+iXw
 aBg
 aBg
 qgt
@@ -66369,10 +68629,10 @@ eqZ
 qgt
 qgt
 qgt
-ddC
+nDU
 bcO
 dcm
-ddC
+nDU
 bcO
 qgt
 erA
@@ -66626,11 +68886,11 @@ eqZ
 qgt
 aBg
 lhh
-ddC
+nDU
 bcO
 dcm
-ddC
-tiN
+nDU
+ikT
 dez
 bcO
 qgt
@@ -66683,7 +68943,7 @@ jAS
 vaM
 cjR
 mQY
-cBc
+iwo
 bOK
 xAV
 aBg
@@ -66882,7 +69142,7 @@ aUL
 eqZ
 qgt
 qgt
-ddC
+nDU
 qsp
 dcm
 dcm
@@ -66942,11 +69202,11 @@ crc
 mnz
 sDu
 xAV
+gyD
+kfp
+iUB
 xAV
-uwU
-uwU
-uwU
-uwU
+xAV
 taJ
 qBx
 xeT
@@ -67138,9 +69398,9 @@ vpj
 qSY
 vId
 qgt
-ddC
+nDU
 lhh
-ddC
+nDU
 moq
 hZx
 joM
@@ -67193,17 +69453,17 @@ izS
 pKy
 sZu
 bmP
-swn
+tHl
 xZT
 aNw
 ePa
 rVh
 lPy
 nfs
-fRe
-fRe
+btA
+lpf
 wUf
-qOk
+phG
 xyO
 fRe
 fRe
@@ -67457,7 +69717,7 @@ mSm
 bJM
 qDf
 wyg
-vpv
+pLp
 ngE
 aLw
 qoH
@@ -67652,7 +69912,7 @@ ucH
 tSN
 vId
 qgt
-ddC
+nDU
 qsp
 deC
 moq
@@ -67713,11 +69973,11 @@ mfJ
 aTt
 uQP
 uQP
-aTt
-uwU
-uwU
-uwU
-uwU
+wPj
+kfp
+iXw
+xAV
+xAV
 mMo
 lDi
 fRe
@@ -67911,7 +70171,7 @@ eqZ
 qgt
 qgt
 erA
-ddC
+nDU
 dcm
 hZx
 hfs
@@ -68165,7 +70425,7 @@ bam
 grI
 bRg
 eqZ
-bsN
+wOL
 qgt
 qgt
 qgt
@@ -69201,7 +71461,7 @@ qgt
 dez
 qgt
 sbu
-ddC
+nDU
 hPE
 hPE
 qCG
@@ -69544,7 +71804,7 @@ srU
 srU
 nor
 srU
-bSi
+aBg
 aBg
 aBg
 aBg
@@ -69775,7 +72035,7 @@ aBg
 qgt
 aBg
 aNZ
-ehk
+pQO
 fRe
 lRU
 qgt
@@ -70024,7 +72284,7 @@ xEs
 pYD
 kOR
 dzI
-roV
+aeZ
 dhA
 aTt
 xje
@@ -70032,7 +72292,7 @@ qgt
 kqG
 qgt
 oDH
-sxm
+ilR
 xxu
 lRU
 qgt
@@ -70090,9 +72350,9 @@ aBg
 aBg
 aBg
 aBg
-aBg
-aBg
-aBg
+oKL
+kOS
+oKL
 aBg
 aBg
 aBg
@@ -70278,7 +72538,7 @@ aNX
 vwF
 uoX
 aTt
-uQP
+lsw
 aTt
 gJI
 rum
@@ -70290,7 +72550,7 @@ qgt
 aBg
 aBg
 aBg
-unC
+uaK
 ykV
 aBg
 aBg
@@ -70309,8 +72569,8 @@ qgt
 vXG
 mBd
 gyR
-gyR
-gyR
+dSe
+lsh
 uZa
 vXG
 qgt
@@ -70346,11 +72606,11 @@ aBg
 aBg
 aBg
 aBg
-aBg
-aBg
-aBg
-aBg
-aBg
+wHx
+wHx
+kOS
+wHx
+wHx
 aBg
 aBg
 aBg
@@ -70547,7 +72807,7 @@ qgt
 aBg
 qgt
 aBg
-qOk
+wlQ
 lRU
 aBg
 aBg
@@ -70558,8 +72818,8 @@ qgt
 qgt
 wlQ
 bSi
-bSi
-drH
+ncz
+neV
 bSi
 qgt
 aBg
@@ -70572,6 +72832,7 @@ wwX
 vXG
 aBg
 qgt
+qgt
 aBg
 aBg
 aBg
@@ -70601,14 +72862,13 @@ aBg
 aBg
 aBg
 aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
+wHx
+wHx
+iBq
+eLG
+cGm
+wHx
+wHx
 aBg
 aBg
 aBg
@@ -70726,7 +72986,7 @@ aBg
 aBg
 aBg
 gzh
-fmi
+qBT
 aBg
 aBg
 aBg
@@ -70823,50 +73083,50 @@ bSi
 bSi
 jSv
 lwp
-qtS
+fRe
 qjJ
 ghV
+ikv
 bSi
-bSi
-bSi
-meg
-wlQ
 qgt
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+wOg
+wOg
+wOg
+wOg
+wOg
+wOg
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+oKL
+wHx
+iBq
+jzT
+rGt
+jzT
+rBo
+wHx
+oKL
 aBg
 aBg
 aBg
@@ -70980,7 +73240,7 @@ aBg
 aBg
 aBg
 aBg
-aBg
+hnP
 fmi
 xVi
 fmi
@@ -71078,51 +73338,51 @@ bSi
 bSi
 bSi
 bSi
-bSi
-bSi
-bSi
-bSi
-bSi
-bSi
-bSi
-meg
+fBW
+eWv
+chh
+eRL
+pAi
+lru
 qgt
 qgt
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
+qgt
+wOg
+wOg
+wOg
+wOg
+wOg
+wOg
+wOg
+qgt
+wOg
+wOg
+wOg
+wOg
+wOg
+wOg
+wOg
+wOg
+wOg
+wOg
+wOg
+wOg
+wOg
+qgt
+qgt
+qgt
+wOg
+wOg
+wOg
+wOg
+wOg
+fbR
+eaq
+dhP
+bDc
+dhP
+xvn
+rdK
 aBg
 aBg
 aBg
@@ -71341,46 +73601,46 @@ bSi
 bSi
 bSi
 bSi
-oDH
-oDH
-oDH
-oLb
+bSi
 aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
+qgt
+qgt
+qgt
+qgt
+qgt
+wOg
+wOg
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+qgt
+oKL
+wHx
+itA
+jzT
+vVs
+jzT
+dKI
+wHx
+oKL
 aBg
 aBg
 aBg
@@ -71495,9 +73755,9 @@ aBg
 aBg
 aBg
 pUI
-eSl
+qKl
 vsr
-eSl
+guY
 wYJ
 aBg
 aBg
@@ -71601,7 +73861,7 @@ oDH
 oDH
 oDH
 oDH
-aBg
+qgt
 qgt
 aBg
 aBg
@@ -71630,13 +73890,13 @@ aBg
 aBg
 aBg
 aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
-aBg
+wHx
+wHx
+mFr
+joe
+pqT
+wHx
+wHx
 aBg
 aBg
 aBg
@@ -71751,10 +74011,10 @@ aBg
 aBg
 fmi
 fmi
-fmi
-fmi
+ihK
+xFh
 eRY
-fmi
+xFh
 wYJ
 aBg
 aBg
@@ -71888,11 +74148,11 @@ aBg
 aBg
 aBg
 aBg
-aBg
-aBg
-aBg
-aBg
-aBg
+wHx
+wHx
+kOS
+cjb
+vVs
 aBg
 aBg
 aBg
@@ -72009,9 +74269,9 @@ aBg
 fmi
 chj
 vks
-vks
+xOp
 otV
-fmi
+aSQ
 wYJ
 qgt
 qgt
@@ -72146,9 +74406,9 @@ aBg
 aBg
 aBg
 aBg
-aBg
-aBg
-aBg
+oKL
+yac
+vVs
 aBg
 aBg
 aBg
@@ -72266,7 +74526,7 @@ aBg
 eSl
 hSY
 mdW
-mdW
+sba
 bmw
 fmi
 wYJ
@@ -72523,7 +74783,7 @@ aBg
 eSl
 hSY
 aLe
-mdW
+sba
 bmw
 fmi
 wYJ
@@ -72778,9 +75038,9 @@ aBg
 aBg
 aBg
 fmi
-hSY
-mdW
-mdW
+cCi
+jgz
+ifd
 gzQ
 fmi
 fmi
@@ -72794,12 +75054,12 @@ qgt
 ssd
 gFo
 lna
-xZq
+lYP
 jxG
 ssd
 aBg
 aBg
-pxb
+deC
 dcm
 wSl
 wnY
@@ -73035,7 +75295,7 @@ aBg
 aBg
 aBg
 fmi
-hSY
+dJV
 mdW
 wWF
 dVg
@@ -73050,14 +75310,14 @@ aBg
 qgt
 ssd
 rQw
-lna
+slK
 cjh
 pSb
 ssd
 qgt
 qgt
 ocT
-ddC
+nDU
 ocT
 fQk
 ocT
@@ -73294,10 +75554,10 @@ aBg
 eSl
 hSY
 mdW
-mdW
-uIc
-mrV
-uIc
+qaD
+wGy
+ceh
+gjp
 lOl
 kBm
 eSl
@@ -73316,8 +75576,8 @@ aBg
 qgt
 qgt
 qgt
-ddC
-ddC
+nDU
+nDU
 xrw
 hPE
 ugh
@@ -73550,12 +75810,12 @@ aBg
 aBg
 eSl
 hSY
-mdW
+pxb
 ckQ
 uIc
 mrV
-uIc
-uIc
+srH
+rGK
 loj
 eSl
 aBg
@@ -73563,10 +75823,10 @@ qgt
 aBg
 aBg
 ssd
-xEI
+fPr
 iTP
 kFv
-xEI
+fPr
 ssd
 ssd
 ssd
@@ -73574,7 +75834,7 @@ ssd
 ssd
 qgt
 qgt
-tiN
+ikT
 rFV
 hPE
 aRf
@@ -73819,20 +76079,20 @@ aBg
 qgt
 aBg
 qgt
-ssd
+bHY
 wqU
 cdf
 voK
 mNB
-ssd
-cjO
+cVQ
+qgt
 qgt
 qgt
 wOL
 aBg
 aBg
 ocT
-ddC
+nDU
 ocT
 rpw
 dcm
@@ -74077,7 +76337,7 @@ qgt
 qgt
 qgt
 ssd
-wqU
+ssd
 nxN
 tDm
 fxz
@@ -74089,9 +76349,9 @@ aBg
 cjO
 aBg
 aBg
-ddC
+nDU
 ocT
-ddC
+nDU
 dcm
 ddC
 qgt
@@ -74347,8 +76607,8 @@ aBg
 qgt
 aBg
 dcm
-tiN
-ddC
+ikT
+nDU
 ocT
 ddC
 qgt
@@ -74393,9 +76653,9 @@ gJY
 lht
 gJY
 mGs
-dJV
-hnP
-dJV
+hVJ
+sMI
+hVJ
 nmY
 nmY
 nmY
@@ -74657,7 +76917,7 @@ osQ
 xUx
 sxX
 ueQ
-hnP
+sMI
 uKw
 rem
 sMI
@@ -75166,7 +77426,7 @@ uTR
 oNf
 gJY
 eIx
-hnP
+sMI
 cUW
 cUW
 hdI
@@ -75376,7 +77636,7 @@ aBg
 aBg
 bas
 bas
-bas
+etX
 aBg
 aBg
 aBg
@@ -75632,7 +77892,7 @@ aBg
 aBg
 aBg
 xlz
-wfA
+wVX
 bas
 aBg
 aBg
@@ -75681,7 +77941,7 @@ xVy
 mGs
 xqP
 cUW
-xOp
+nfV
 cUW
 hdI
 fMu
@@ -75884,12 +78144,12 @@ aBg
 aBg
 qgt
 iXX
-slK
+wCO
 wCO
 iXX
 sTo
 aBg
-ihK
+qvL
 qgt
 aBg
 aBg
@@ -76140,12 +78400,12 @@ aBg
 aBg
 aBg
 qgt
-bas
+ebu
 jaD
-cYu
-bas
+cdr
+cWp
 qgt
-ihK
+qvL
 pYo
 qgt
 qgt
@@ -76188,7 +78448,7 @@ aBg
 jeD
 aBg
 fMu
-hnP
+sMI
 fMu
 aBg
 aBg
@@ -76394,23 +78654,23 @@ aBg
 aBg
 aBg
 aBg
-sTo
+aBg
 bas
 htx
-bas
+mHN
 vtL
 xag
-bas
+mHN
 qgt
-ihK
-ihK
+qvL
+qvL
 qgt
 qgt
 cjO
 cjO
 qgv
 mGk
-cCi
+qgv
 qgv
 qgt
 aBg
@@ -76651,16 +78911,16 @@ aBg
 aBg
 aBg
 aBg
-qgt
-bas
-hHL
-bas
+fqJ
+ttn
+kqz
+brV
 qzA
 xho
-bas
+rVK
 qgt
 wVX
-ihK
+qvL
 aBg
 qgt
 cjO
@@ -76668,7 +78928,7 @@ qgv
 qgv
 rQF
 qgv
-qKl
+xFp
 tHW
 aBg
 cjO
@@ -76911,18 +79171,18 @@ qgt
 qgt
 bas
 bas
-bas
+lme
 cxT
 eDD
+rVK
 bas
 bas
-bas
-xFh
+azK
 cjO
 qgt
 qgv
-qKl
-tHW
+xFp
+xiC
 rQF
 xFp
 qgv
@@ -77170,7 +79430,7 @@ bas
 oDU
 sdw
 hJi
-vLU
+tmV
 xoj
 uqj
 bas
@@ -77427,7 +79687,7 @@ mtT
 aIc
 kgf
 xjO
-vLU
+tmV
 uhG
 uYM
 lMt
@@ -77502,13 +79762,13 @@ qEP
 gVJ
 tdl
 aBg
-dFY
+jvM
 lgP
 eDP
 tJw
 jvM
 dVT
-kNT
+fOZ
 tZC
 kNT
 fPe
@@ -77686,7 +79946,7 @@ gEm
 xjO
 dEP
 xVA
-cYu
+com
 iWn
 cVn
 cjO
@@ -77941,7 +80201,7 @@ lad
 uOF
 mBE
 xjO
-vLU
+tmV
 qEc
 vAf
 nrO
@@ -77989,10 +80249,10 @@ ufz
 ufz
 krG
 krG
-hJc
-aMC
+eZO
+kVs
 bfl
-hJc
+gLC
 krG
 krG
 krG
@@ -78024,7 +80284,7 @@ leD
 hxw
 kNT
 tSz
-kNT
+stq
 dgD
 lxM
 hfM
@@ -78198,7 +80458,7 @@ tFt
 aej
 ree
 xjO
-vLU
+tmV
 lwg
 aej
 raF
@@ -78246,10 +80506,10 @@ kjA
 ufz
 pFL
 krG
-hJc
+mBn
 qBB
 wXy
-hJc
+xtE
 krG
 pFL
 krG
@@ -78455,7 +80715,7 @@ wqt
 cYu
 iNx
 xjO
-vLU
+tmV
 kcm
 qfu
 fVc
@@ -78484,7 +80744,7 @@ bDY
 bDY
 bDY
 qgv
-mGk
+rln
 qgv
 qgt
 aBg
@@ -78503,10 +80763,10 @@ slP
 ufz
 krG
 krG
-hJc
+mBn
 pDZ
 qhG
-hJc
+waV
 pFL
 pFL
 pFL
@@ -78712,7 +80972,7 @@ pXI
 cJd
 mWS
 xjO
-vLU
+tmV
 vPB
 cJd
 vHN
@@ -78721,7 +80981,7 @@ aBg
 qgt
 aBg
 aBg
-jgz
+xiC
 qgv
 rQF
 bOf
@@ -78760,8 +81020,8 @@ ufz
 ufz
 ufz
 ufz
-ufz
-vTa
+eCQ
+wRo
 eaa
 hJc
 krG
@@ -78999,8 +81259,8 @@ rQF
 rQF
 rQF
 rQF
-jgz
-mGk
+xiC
+rln
 aBg
 aBg
 aBg
@@ -79017,7 +81277,7 @@ bBQ
 bBQ
 ihe
 sFT
-ufz
+eCQ
 djQ
 pej
 hJc
@@ -79039,10 +81299,10 @@ aBg
 aBg
 aBg
 aBg
-gNn
+idD
 nYz
-gVJ
-rRR
+xVv
+lyM
 tmd
 tmd
 gBF
@@ -79224,9 +81484,9 @@ bas
 cVn
 gHE
 wUv
-kgf
+dcz
 xjO
-vLU
+tmV
 uhG
 wUv
 fVc
@@ -79274,7 +81534,7 @@ tLJ
 eYH
 eJp
 tPA
-ufz
+eCQ
 vTa
 pej
 hJc
@@ -79296,9 +81556,9 @@ aBg
 aBg
 aBg
 aBg
-gNn
+rPw
 skJ
-gNn
+rPw
 gNn
 tmd
 hSR
@@ -79481,10 +81741,10 @@ qgt
 bas
 lCJ
 acT
-gEm
+joz
 dDx
-vLU
-xVA
+tmV
+cAB
 sBo
 uqC
 bas
@@ -79531,7 +81791,7 @@ tLJ
 tLJ
 gcx
 pHq
-ufz
+eCQ
 oPk
 pej
 jNZ
@@ -79553,19 +81813,19 @@ jeD
 jeD
 jeD
 jeD
-gVJ
+wpk
 lZk
 xMg
 vjb
 tmd
 tTx
-xPU
+rEd
 rpW
 oMQ
 ekS
 uvq
 wVl
-erD
+krI
 fYC
 cwS
 cLn
@@ -79822,8 +82082,8 @@ qta
 ekS
 vDf
 pGH
-erD
-pGH
+sNi
+tBI
 glk
 jxK
 jMz
@@ -80069,7 +82329,7 @@ jeD
 jeD
 gNn
 hRy
-fJh
+nGO
 jMb
 gTP
 rov
@@ -80560,7 +82820,7 @@ qJH
 tLJ
 cgE
 ufz
-vTa
+iXa
 npz
 jNZ
 hTG
@@ -80588,7 +82848,7 @@ cFp
 tmd
 eub
 czY
-xPU
+wMd
 kay
 ekS
 iqr
@@ -80845,7 +83105,7 @@ gNn
 tmd
 nsx
 aVb
-aVb
+qVa
 lRo
 ekS
 uzU
@@ -81102,7 +83362,7 @@ jeD
 tmd
 ekS
 jCx
-jCx
+jxr
 ekS
 ekS
 bCw
@@ -81355,11 +83615,11 @@ aBg
 aBg
 aBg
 aBg
-aBg
-seo
-omI
+fyz
+aES
+bko
 dVp
-dVp
+ivv
 gCr
 mRZ
 mRk
@@ -81613,10 +83873,10 @@ seo
 seo
 seo
 seo
-seo
+okc
 rTP
-xHz
-xHz
+aZr
+mKB
 kgd
 mRZ
 wFM
@@ -81834,19 +84094,19 @@ krG
 krG
 hJc
 hJc
-hJc
-hJc
-hJc
-hJc
+oXn
+oXn
+oXn
+oXn
 dTq
 qUD
 thH
 dTq
-hJc
-hJc
-hJc
+oXn
+oXn
+oXn
 aXf
-bHY
+npz
 jNZ
 cKG
 pEn
@@ -81873,7 +84133,7 @@ sKg
 bsz
 pSA
 xHz
-xHz
+jhz
 fxy
 mRZ
 vYb
@@ -82101,9 +84361,9 @@ osw
 rNc
 shU
 uFL
-hJc
+oXn
 aXf
-pej
+npz
 jNZ
 drK
 lap
@@ -82130,12 +84390,12 @@ sEa
 iTT
 xNd
 xHz
-xHz
+jhz
 oqu
 mRZ
 sOG
 bIJ
-bIJ
+lAY
 tpQ
 gVK
 gCW
@@ -82358,7 +84618,7 @@ eCU
 uvr
 bUZ
 aSa
-hJc
+oXn
 aXf
 sAj
 jNZ
@@ -82387,13 +84647,13 @@ rKz
 bsz
 sap
 xHz
-xHz
+jhz
 fxy
 mRZ
 kjl
 pGH
-pGH
-erD
+xRb
+idi
 lRt
 jxK
 jMz
@@ -82613,11 +84873,11 @@ hKX
 gKe
 gym
 gLu
-fPr
+gLu
 sKI
-hJc
+oXn
 aXf
-eaa
+sYO
 jNZ
 iyy
 tXU
@@ -82642,14 +84902,14 @@ seo
 seo
 seo
 seo
-rTP
-xHz
-xHz
-kgd
+rCL
+lgM
+fSY
+xCZ
 mRZ
 xMT
 wVl
-eGg
+nmk
 fFJ
 ijp
 jxK
@@ -82872,9 +85132,9 @@ jZz
 iKp
 waq
 dbM
-hJc
+oXn
 aXf
-pej
+npz
 jNZ
 tXU
 iyy
@@ -82906,7 +85166,7 @@ gCr
 mRZ
 tXv
 otL
-pGH
+sdE
 erD
 pFV
 jxK
@@ -83120,17 +85380,17 @@ krG
 pFL
 pFL
 oXn
-hJc
-hJc
-hJc
-hJc
-hJc
-hJc
-hJc
-eZO
-hJc
-hJc
-aXf
+oXn
+oXn
+oXn
+oXn
+oXn
+oXn
+oXn
+sgs
+uZt
+uZt
+pyl
 daF
 jNZ
 gWi
@@ -83163,7 +85423,7 @@ bYZ
 mRZ
 kIM
 pGH
-pGH
+sdE
 fFJ
 nsO
 jxK
@@ -83388,7 +85648,7 @@ tGE
 pFL
 hJc
 aXf
-pej
+npz
 jNZ
 jNZ
 jNZ
@@ -83645,7 +85905,7 @@ tGE
 pFL
 hJc
 aXf
-pej
+npz
 hJc
 krG
 pFL
@@ -83902,7 +86162,7 @@ tGE
 krG
 hJc
 aXf
-pej
+npz
 hJc
 krG
 krG
@@ -84157,10 +86417,10 @@ krG
 krG
 tGE
 krG
-hJc
+udN
 oxW
 xxE
-hJc
+qtO
 krG
 krG
 krG
@@ -84190,9 +86450,9 @@ vBe
 vBe
 nxa
 tQA
-vTY
-fZr
-vTY
+vro
+alC
+sqg
 npc
 wHq
 gkh
@@ -84414,10 +86674,10 @@ aBg
 aBg
 bze
 jeD
-hJc
+sRz
 kwK
 aHp
-hJc
+mBn
 krG
 krG
 krG
@@ -84671,10 +86931,10 @@ aBg
 aBg
 aBg
 aBg
-hJc
+agX
 kVs
 aSL
-hJc
+wPV
 krG
 aBg
 aBg

--- a/_maps/map_files/OrbitalStation/OrbitalStation.dmm
+++ b/_maps/map_files/OrbitalStation/OrbitalStation.dmm
@@ -887,7 +887,7 @@
 	},
 /area/science/research/abandoned)
 "aIR" = (
-/obj/machinery/autolathe/hacked,
+/obj/machinery/modular_fabricator/autolathe/hacked,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -14490,7 +14490,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/mecha_part_fabricator/maint{
+/obj/machinery/modular_fabricator/exosuit_fab/maint{
 	name = "forgotten exosuit fabricator"
 	},
 /obj/structure/sign/poster/official/safety_eye_protection{
@@ -17715,7 +17715,7 @@
 /area/hallway/secondary/exit)
 "moe" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/mecha_part_fabricator,
+/obj/machinery/modular_fabricator/exosuit_fab,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/science/lab)
@@ -19506,7 +19506,7 @@
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/space/derelict/singularity_engine)
 "nDz" = (
-/obj/machinery/mecha_part_fabricator/maint{
+/obj/machinery/modular_fabricator/exosuit_fab/maint{
 	name = "forgotten exosuit fabricator"
 	},
 /turf/open/floor/plating{

--- a/_maps/orbitalstation.json
+++ b/_maps/orbitalstation.json
@@ -3,9 +3,9 @@
     "map_path": "map_files/OrbitalStation",
     "map_file": "OrbitalStation.dmm",
     "shuttles": {
-	    "emergency": "emergency_box",
-	    "whiteship": "whiteship_delta",
-	    "ferry": "ferry_fancy",
-	    "cargo": "cargo_delta"
+	    "cargo": "cargo_delta",
+		"ferry": "ferry_fancy",
+		"whiteship": "whiteship_delta",
+		"emergency": "emergency_orbital"
     }
 }

--- a/_maps/shuttles/emergency_orbital.dmm
+++ b/_maps/shuttles/emergency_orbital.dmm
@@ -1,0 +1,626 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/turf/template_noop,
+/area/template_noop)
+"ac" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"ad" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"ae" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"af" = (
+/obj/machinery/computer/communications,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"ag" = (
+/obj/machinery/computer/security{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"ah" = (
+/obj/machinery/computer/crew{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"ai" = (
+/obj/machinery/light,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"al" = (
+/obj/machinery/button/flasher{
+	id = "cockpit_flasher";
+	pixel_x = 6;
+	pixel_y = -24
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"am" = (
+/obj/machinery/computer/station_alert{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"an" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/crowbar,
+/obj/item/storage/firstaid/fire,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"ap" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/machinery/flasher{
+	id = "cockpit_flasher";
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"aq" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"ar" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"as" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"at" = (
+/obj/machinery/light,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"au" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"az" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"aB" = (
+/obj/machinery/computer/emergency_shuttle,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"aC" = (
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"aE" = (
+/turf/closed/wall/mineral/titanium/interior,
+/area/shuttle/escape)
+"aF" = (
+/obj/machinery/computer/atmos_alert{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"aJ" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"aK" = (
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"aM" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"aR" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"aS" = (
+/obj/structure/table,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"aT" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"aW" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Brig";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"bb" = (
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"bc" = (
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/structure/closet/crate{
+	name = "lifejackets"
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"bd" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/button/flasher{
+	id = "shuttle_flasher";
+	pixel_x = 24;
+	pixel_y = -6
+	},
+/obj/machinery/flasher{
+	id = "shuttle_flasher";
+	pixel_x = 24;
+	pixel_y = 6
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"be" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"bf" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"bg" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/emergency{
+	pixel_x = 3;
+	pixel_y = -5
+	},
+/obj/item/crowbar,
+/obj/item/wrench,
+/obj/item/radio,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"bi" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/shuttle/engine/heater,
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"bj" = (
+/obj/machinery/stasis,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"bk" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"bl" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/crowbar,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"bm" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Cockpit";
+	req_access_txt = "19"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"bn" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"bo" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"bp" = (
+/obj/structure/rack,
+/obj/item/tank/internals/oxygen/red,
+/obj/item/clothing/suit/fire/firefighter,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/head/hardhat/red,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"bq" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"bs" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Infirmary"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"ga" = (
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"mA" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"BZ" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"Dd" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Cargo"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"JW" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Km" = (
+/obj/docking_port/mobile/emergency{
+	name = "Orbital emergency shuttle"
+	},
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"Lm" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	use_power = 0
+	},
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"XC" = (
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+
+(1,1,1) = {"
+aa
+aE
+ad
+JW
+ad
+Km
+JW
+JW
+JW
+JW
+ad
+ad
+ad
+mA
+ad
+mA
+ad
+ad
+"}
+(2,1,1) = {"
+aE
+aE
+aF
+ah
+ad
+bn
+bo
+as
+au
+bo
+as
+bo
+ad
+bb
+bq
+bb
+bi
+bk
+"}
+(3,1,1) = {"
+JW
+ae
+aT
+aJ
+ad
+bn
+aC
+as
+au
+aC
+as
+aC
+ad
+bf
+bb
+bb
+bi
+bk
+"}
+(4,1,1) = {"
+JW
+ac
+aC
+ai
+ad
+bn
+aC
+as
+au
+aC
+as
+aC
+Dd
+bb
+bb
+bb
+bi
+bk
+"}
+(5,1,1) = {"
+JW
+af
+aC
+al
+ad
+ap
+aC
+as
+au
+aC
+as
+aC
+ad
+bc
+bb
+bg
+bi
+bk
+"}
+(6,1,1) = {"
+JW
+aB
+aC
+aC
+bm
+aC
+aC
+aC
+az
+aC
+aC
+aC
+ad
+bc
+bb
+bp
+bi
+bk
+"}
+(7,1,1) = {"
+JW
+ac
+aC
+at
+ad
+aS
+aS
+aC
+BZ
+XC
+aW
+XC
+ad
+XC
+bs
+XC
+bi
+bk
+"}
+(8,1,1) = {"
+JW
+an
+aM
+aM
+ad
+aT
+aT
+aC
+ad
+aK
+aK
+aK
+Lm
+ga
+ga
+ga
+bi
+bk
+"}
+(9,1,1) = {"
+ad
+aE
+ag
+am
+ad
+aq
+ar
+aC
+ad
+aR
+bd
+be
+ad
+bj
+bl
+bj
+bi
+bk
+"}
+(10,1,1) = {"
+aa
+aE
+ad
+JW
+ad
+ad
+JW
+JW
+ad
+ad
+ad
+ad
+ad
+JW
+ad
+JW
+ad
+ad
+"}

--- a/austation.dme
+++ b/austation.dme
@@ -29,15 +29,6 @@
 // END_BEESTATION_INCLUDE
 
 // BEGIN_INCLUDE
-#include "austation\code\__DEFINES\admin.dm"
-#include "austation\code\__DEFINES\coilgun.dm"
-#include "austation\code\__DEFINES\lavaland.dm"
-#include "austation\code\__DEFINES\maths.dm"
-#include "austation\code\__DEFINES\misc.dm"
-#include "austation\code\__DEFINES\mobs.dm"
-#include "austation\code\__DEFINES\movespeed_modification.dm"
-#include "austation\code\__DEFINES\RPD.dm"
-#include "austation\code\__DEFINES\traits.dm"
 #include "austation\code\__HELPERS\matrices.dm"
 #include "austation\code\__HELPERS\roundend.dm"
 #include "austation\code\_globalvars\coilgun.dm"

--- a/austation.dme
+++ b/austation.dme
@@ -29,6 +29,15 @@
 // END_BEESTATION_INCLUDE
 
 // BEGIN_INCLUDE
+#include "austation\code\__DEFINES\admin.dm"
+#include "austation\code\__DEFINES\coilgun.dm"
+#include "austation\code\__DEFINES\lavaland.dm"
+#include "austation\code\__DEFINES\maths.dm"
+#include "austation\code\__DEFINES\misc.dm"
+#include "austation\code\__DEFINES\mobs.dm"
+#include "austation\code\__DEFINES\movespeed_modification.dm"
+#include "austation\code\__DEFINES\RPD.dm"
+#include "austation\code\__DEFINES\traits.dm"
 #include "austation\code\__HELPERS\matrices.dm"
 #include "austation\code\__HELPERS\roundend.dm"
 #include "austation\code\_globalvars\coilgun.dm"
@@ -40,6 +49,7 @@
 #include "austation\code\controllers\subsystem\job.dm"
 #include "austation\code\datums\ai_laws.dm"
 #include "austation\code\datums\emotes.dm"
+#include "austation\code\datums\shuttles.dm"
 #include "austation\code\datums\brain_damage\imaginary_friend.dm"
 #include "austation\code\datums\components\spikes.dm"
 #include "austation\code\datums\components\crafting\crafting.dm"

--- a/austation/code/datums/shuttles.dm
+++ b/austation/code/datums/shuttles.dm
@@ -1,0 +1,4 @@
+/datum/map_template/shuttle/emergency/orbital
+	suffix = "orbital"
+	name = "Orbital Station Emergency Shuttle"
+	can_be_bought = FALSE


### PR DESCRIPTION
A bunch of atmos & QoL improvements for orbital that are probably half a year overdue.
 The shuttle is just a slimmer, modified version of boxstation's for now. 

## Changelog
:cl:
add: external airlock cycling to orbital
add: atmos piping to most detached structures on orbital
add: unique emergency shuttle for orbital
/:cl:

