### PR TITLE
Energy Weapon Size Revert

### DIFF
--- a/austation.dme
+++ b/austation.dme
@@ -209,6 +209,7 @@
 #include "austation\code\modules\projectiles\boxes_magazine\internal\makeshift_mags.dm"
 #include "austation\code\modules\projectiles\guns\ballistic\crossbow.dm"
 #include "austation\code\modules\projectiles\guns\ballistic\makeshift_pistol.dm"
+#include "austation\code\modules\projectiles\guns\energy\energy_gun.dm"
 #include "austation\code\modules\projectiles\guns\misc\chem_gun.dm"
 #include "austation\code\modules\reagents\chemistry\reagents.dm"
 #include "austation\code\modules\reagents\chemistry\recipes.dm"

--- a/austation/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/austation/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -1,0 +1,2 @@
+/obj/item/gun/energy/e_gun
+	w_class = WEIGHT_CLASS_NORMAL


### PR DESCRIPTION
**Changes back energy weapons to normal size instead of bulky**

This sort of change needs to not be done piece meal. Has the expected effect of making the gap even wider between balistics and energy weapons to the point that sec throwing away their energy weapons to buy wt550's is the most viable thing sec can do.

If someone wants inventory management to be more important than it already is they should do a big overhaul at once not just a few items.

## Changelog
:cl:
tweak: energy weapons are now normal instead of bulky
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
