### PR TITLE
Revert Remove CBZ (now modular)

### DIFF
--- a/austation/code/modules/cargo/packs/packs.dm
+++ b/austation/code/modules/cargo/packs/packs.dm
@@ -47,3 +47,10 @@
 	crate_name = "Build Your Own Reactor Kit"
 	crate_type = /obj/structure/closet/crate/secure/engineering
 	dangerous = TRUE
+
+/datum/supply_pack/security/armory/cling_test
+	name = "Changeling Testing Kit"
+	desc = "Contains a single bottle of concentrated BZ, used for detecting and incapacitating changelings. Due to the rarity of this chemical, the cost is extortionate, and security personnel are recommended to visit their local chemistry department instead if possible. Requires Armory access to open."
+	cost = 10000
+	contains = list(/obj/item/reagent_containers/glass/bottle/concentrated_bz)
+	crate_name = "Changeling testing kit crate"

--- a/austation/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/austation/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -265,7 +265,7 @@
 				L.emote("gasp")
 				to_chat(L, "<font size=3 color=red><b>You can't breathe!</b></font>")
 
-		L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2, 50)
+		L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 50, 90)
 	return ..()
 
 /datum/reagent/fake_cbz
@@ -276,6 +276,6 @@
 	random_unrestricted = FALSE
 
 /datum/reagent/fake_cbz/on_mob_life(mob/living/L)
-	L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2, 50)
+	L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 25, 90)
 	if(prob(15))
 		to_chat(L, "You don't feel much of anything")

--- a/austation/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/austation/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -238,3 +238,44 @@
 	if(methods & TOUCH)
 		M.adjustFireLoss(2, 0) // burns
 	..()
+
+/datum/reagent/concentrated_bz
+	name = "Concentrated BZ"
+	description = "A hyperconcentrated liquid form of BZ gas, known to cause an extremely adverse reaction to changelings. Also causes minor brain damage."
+	color = "#FAFF00"
+	taste_description = "acrid cinnamon"
+	random_unrestricted = FALSE
+
+/datum/reagent/concentrated_bz/on_mob_metabolize(mob/living/L)
+	..()
+	ADD_TRAIT(L, CHANGELING_HIVEMIND_MUTE, type)
+
+/datum/reagent/concentrated_bz/on_mob_end_metabolize(mob/living/L)
+	..()
+	REMOVE_TRAIT(L, CHANGELING_HIVEMIND_MUTE, type)
+
+/datum/reagent/concentrated_bz/on_mob_life(mob/living/L)
+	if(L.mind)
+		var/datum/antagonist/changeling/changeling = L.mind.has_antag_datum(/datum/antagonist/changeling)
+		if(changeling)
+			changeling.chem_charges = max(changeling.chem_charges-2, 0)
+			if(prob(30))
+				L.losebreath += 1
+				L.adjustOxyLoss(3,5)
+				L.emote("gasp")
+				to_chat(L, "<font size=3 color=red><b>You can't breathe!</b></font>")
+
+		L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2, 50)
+	return ..()
+
+/datum/reagent/fake_cbz
+	name = "Concentrated BZ"
+	description = "A hyperconcentrated liquid form of BZ gas, known to cause an extremely adverse reaction to changelings. Also causes minor brain damage."
+	color = "#FAFF00"
+	taste_description = "acrid cinnamon"
+	random_unrestricted = FALSE
+
+/datum/reagent/fake_cbz/on_mob_life(mob/living/L)
+	L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2, 50)
+	if(prob(15))
+		to_chat(L, "You don't feel much of anything")

--- a/austation/code/modules/reagents/chemistry/recipes/others.dm
+++ b/austation/code/modules/reagents/chemistry/recipes/others.dm
@@ -43,3 +43,15 @@
 	results = list(/datum/reagent/acetaldehyde = 3)
 	required_reagents = list(/datum/reagent/acetone = 1, /datum/reagent/toxin/formaldehyde = 1, /datum/reagent/water = 1)
 	required_temp = 450
+
+/datum/chemical_reaction/concentrated_bz
+	name = "Concentrated BZ"
+	id = "Concentrated BZ"
+	results = list(/datum/reagent/concentrated_bz = 10)
+	required_reagents = list(/datum/reagent/toxin/plasma = 40, /datum/reagent/nitrous_oxide = 10)
+
+/datum/chemical_reaction/fake_cbz
+	name = "Fake CBZ"
+	id = "Fake CBZ"
+	results = list(/datum/reagent/fake_cbz = 1)
+	required_reagents = list(/datum/reagent/concentrated_bz = 1, /datum/reagent/medicine/neurine = 3)

--- a/austation/code/modules/reagents/reagent_containers/bottle.dm
+++ b/austation/code/modules/reagents/reagent_containers/bottle.dm
@@ -2,3 +2,8 @@
 	name = "sarin bottle"
 	desc = "A small bottle of sarin"
 	list_reagents = list(/datum/reagent/toxin/sarin = 30)
+
+/obj/item/reagent_containers/glass/bottle/concentrated_bz
+	name = "concentrated BZ bottle"
+	desc = "A small bottle of concentrated BZ"
+	list_reagents = list(/datum/reagent/concentrated_bz = 30)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

CBZ was the only way of detecting a ling without randomly guessing and now just as before 10u of CBZ is enough to deal 51 oxyloss 
## Why It's Good For The Game

Allows security a definite chance of finding a ling (unless its fake CBZ), its a skill issue if the ling cant either prevent chemists from making the CBZ or getting rid of the plasma to produce it

## Changelog
:cl:
add: CBZ, a ling finding agent, but be careful of using it, it may cause quite a bit of brain damage
add: Fake CBZ, so lings have a chance of turning the tide
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
