### PR TITLE
Syndicate Name Generation Reference 2

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -121,7 +121,7 @@ GLOBAL_VAR(command_name)
 	var/name = ""
 
 	// Prefix
-	name += pick("Clandestine", "Prima", "Blue", "Zero-G", "Max", "Blasto", "Waffle", "North", "Omni", "Newton", "Cyber", "Bonk", "Gene", "Gib", "Solo-Nobre", "Volta", "Gravesend", "Luddite", "Tri-Tach") // austation -- PR: #3688 Added prefix "Solo-Nobre", PR: # Added prefixes "Volta", "Gravesend", "Luddite", "Tri-Tach"
+	name += pick("Clandestine", "Prima", "Blue", "Zero-G", "Max", "Blasto", "Waffle", "North", "Omni", "Newton", "Cyber", "Bonk", "Gene", "Gib", "Solo-Nobre", "Volta", "Gravesend", "Luddite", "Tri-Tach") // austation -- PR: #3688 Added prefix "Solo-Nobre", PR: #3742 Added prefixes "Volta", "Gravesend", "Luddite", "Tri-Tach"
 
 	// Suffix
 	if (prob(80))

--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -121,7 +121,7 @@ GLOBAL_VAR(command_name)
 	var/name = ""
 
 	// Prefix
-	name += pick("Clandestine", "Prima", "Blue", "Zero-G", "Max", "Blasto", "Waffle", "North", "Omni", "Newton", "Cyber", "Bonk", "Gene", "Gib", "Solo-Nobre") // austation -- PR: #3688 Added prefix "Solo-Nobre"
+	name += pick("Clandestine", "Prima", "Blue", "Zero-G", "Max", "Blasto", "Waffle", "North", "Omni", "Newton", "Cyber", "Bonk", "Gene", "Gib", "Solo-Nobre", "Volta", "Gravesend", "Luddite", "Tri-Tach") // austation -- PR: #3688 Added prefix "Solo-Nobre", PR: # Added prefixes "Volta", "Gravesend", "Luddite", "Tri-Tach"
 
 	// Suffix
 	if (prob(80))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds prefixes "Volta", "Gravesend", "Luddite", "Tri-Tach" to Syndicate Name Generation.

## Changelog
:cl:
add: Added more prefixes for syndicate name generation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
