### PR TITLE
fixes necro chest lookup table

### DIFF
--- a/austation/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/austation/code/modules/mining/lavaland/necropolis_chests.dm
@@ -10,7 +10,7 @@ Beeloot is the number of items in Bees loot table excluding disabled loot
 	if(!istype(item, /obj/item/skeleton_key) || spawned_loot)
 		return FALSE
 
-	var/loot = rand(1,32)
+	var/loot = rand(1,30)
 
 	switch(loot)
 		if(1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lookup table for necro chest was looking for items that weren't there with rand(1,32). Loot table goes up to 30 so if it hits 31 or 32 it spits nothing out.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes necro chests not give you nothing
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: necro chest lookup table isn't looking for nothing anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
