### PR TITLE
Round Start Austation Airlock Fix

### DIFF
--- a/_maps/map_files/Austation/Austation.dmm
+++ b/_maps/map_files/Austation/Austation.dmm
@@ -2725,8 +2725,9 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "akd" = (
+/obj/structure/window/reinforced,
 /turf/open/space,
-/area/maintenance/solars/starboard/fore)
+/area/aisat)
 "ake" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -7089,7 +7090,7 @@
 "aGh" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/closed/wall,
-/area/chapel/main)
+/area/hallway/secondary/exit/departure_lounge)
 "aGm" = (
 /obj/structure/table,
 /obj/item/hand_labeler,
@@ -13096,8 +13097,12 @@
 	},
 /area/engine/storage_shared)
 "beq" = (
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/space,
+/area/aisat)
 "beu" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -54590,7 +54595,7 @@
 	dir = 6
 	},
 /turf/closed/wall,
-/area/hallway/secondary/exit/departure_lounge)
+/area/maintenance/aft/secondary)
 "jUX" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -59988,7 +59993,7 @@
 	dir = 4
 	},
 /turf/closed/wall,
-/area/crew_quarters/fitness/recreation)
+/area/maintenance/starboard/fore)
 "miv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -65997,7 +66002,7 @@
 "oya" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/r_wall,
-/area/space/nearstation)
+/area/aisat)
 "oyg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -71004,7 +71009,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
+/area/maintenance/starboard/fore)
 "qwE" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -71234,6 +71239,16 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/science/test_area)
+"qAR" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/turf/open/space,
+/area/aisat)
 "qBh" = (
 /obj/structure/table,
 /obj/item/paicard,
@@ -75537,6 +75552,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"sow" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/engine/break_room)
 "soB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -76767,6 +76791,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"sRd" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/engine/break_room)
 "sRl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
@@ -77558,7 +77592,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos)
+/area/engine/break_room)
 "tfX" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -81040,7 +81074,7 @@
 	dir = 6
 	},
 /turf/closed/wall,
-/area/hallway/secondary/exit/departure_lounge)
+/area/maintenance/aft/secondary)
 "uAK" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L13"
@@ -83195,9 +83229,12 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "vtG" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/closed/wall,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/turf/open/space,
+/area/aisat)
 "vtT" = (
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Fore";
@@ -88914,7 +88951,7 @@
 	dir = 5
 	},
 /turf/closed/wall,
-/area/chapel/main)
+/area/hallway/secondary/exit/departure_lounge)
 "xKX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -115104,7 +115141,7 @@ cMI
 dUI
 aGh
 xKV
-cMI
+cPb
 aaa
 aaa
 aaa
@@ -119466,7 +119503,7 @@ cPb
 cPb
 uAH
 jUT
-vtG
+lYM
 aaa
 aaa
 aaa
@@ -131440,9 +131477,9 @@ aaa
 aaa
 acP
 acQ
-acP
+dnh
 mis
-acP
+dnh
 acP
 dnS
 dnS
@@ -131954,9 +131991,9 @@ aaa
 aaa
 aiZ
 ack
-ajb
+dqT
 qwt
-ajb
+dqT
 ajb
 ajb
 ajb
@@ -133542,7 +133579,7 @@ iSE
 bDT
 rjL
 gst
-tEg
+sRd
 kAJ
 bAN
 pOb
@@ -133799,7 +133836,7 @@ qKK
 vtv
 bhT
 tUN
-sph
+sow
 rew
 eLx
 bCv
@@ -134268,7 +134305,7 @@ aaf
 aaa
 aaa
 aaf
-akd
+aav
 alv
 xdN
 ugF
@@ -134782,7 +134819,7 @@ aaf
 aaa
 aaa
 aaf
-akd
+aav
 alv
 lvY
 ugF
@@ -135041,7 +135078,7 @@ aaa
 aaf
 aaa
 aaa
-akd
+aav
 alv
 apm
 apm
@@ -141499,10 +141536,10 @@ anT
 aaa
 aqB
 aaa
-aMq
+akd
 bgc
 bgc
-aOV
+vtG
 blw
 aNw
 jYt
@@ -141756,10 +141793,10 @@ anT
 aaa
 anT
 aaa
-aMq
+akd
 bgd
 jXK
-aOV
+vtG
 aMq
 rAx
 sRS
@@ -142013,7 +142050,7 @@ anT
 aaa
 anT
 anT
-beq
+aRy
 gJa
 cZg
 oya
@@ -142270,10 +142307,10 @@ anT
 anT
 anT
 aaa
-aSD
+beq
 hpY
 hpY
-aOX
+qAR
 bly
 vSn
 fkv

--- a/_maps/map_files/Austation/Austation.dmm
+++ b/_maps/map_files/Austation/Austation.dmm
@@ -2734,7 +2734,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/maintenance/solars/starboard/fore)
+/area/solar/starboard/fore)
 "akf" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -67516,6 +67516,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"oYW" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/engine/break_room)
 "oZr" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -71239,16 +71249,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/science/test_area)
-"qAR" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/turf/open/space,
-/area/aisat)
 "qBh" = (
 /obj/structure/table,
 /obj/item/paicard,
@@ -73935,6 +73935,16 @@
 "rHe" = (
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"rHh" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/turf/open/space,
+/area/aisat)
 "rHm" = (
 /obj/structure/chair,
 /obj/machinery/camera{
@@ -75552,15 +75562,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"sow" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/engine/break_room)
 "soB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -76791,16 +76792,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"sRd" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/visible,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/engine/break_room)
 "sRl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
@@ -88734,6 +88725,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"xFq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/engine/break_room)
 "xFr" = (
 /obj/machinery/newscaster{
 	pixel_x = -32
@@ -133579,7 +133579,7 @@ iSE
 bDT
 rjL
 gst
-sRd
+oYW
 kAJ
 bAN
 pOb
@@ -133836,7 +133836,7 @@ qKK
 vtv
 bhT
 tUN
-sow
+xFq
 rew
 eLx
 bCv
@@ -142310,7 +142310,7 @@ aaa
 beq
 hpY
 hpY
-qAR
+rHh
 bly
 vSn
 fkv


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes all airlock controllers properly recognise interior and exterior airlocks
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A handful of airlocks on Austation couldn't cycle properly at round start due to mapping errors. It was fixed on Metastation, but the changes never made their way to Austation. This fixes those errors, allowing all airlocks to properly cycle round start.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Austation airlocks now all cycle properly round start
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
