### PR TITLE
Expanded alerts for Malf ai fake alert module

### DIFF
--- a/code/modules/events/communications_blackout.dm
+++ b/code/modules/events/communications_blackout.dm
@@ -2,6 +2,7 @@
 	name = "Communications Blackout"
 	typepath = /datum/round_event/communications_blackout
 	weight = 30
+	can_malf_fake_alert = TRUE
 
 /datum/round_event/communications_blackout
 	announceWhen	= 1

--- a/code/modules/events/communications_blackout.dm
+++ b/code/modules/events/communications_blackout.dm
@@ -2,7 +2,7 @@
 	name = "Communications Blackout"
 	typepath = /datum/round_event/communications_blackout
 	weight = 30
-	can_malf_fake_alert = TRUE
+	can_malf_fake_alert = TRUE //Austation addition
 
 /datum/round_event/communications_blackout
 	announceWhen	= 1

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -5,6 +5,7 @@
 	min_players = 10
 	weight = 5
 	earliest_start = 10 MINUTES
+	can_malf_fake_alert = TRUE
 
 /datum/round_event/disease_outbreak
 	announceWhen	= 15

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -5,7 +5,7 @@
 	min_players = 10
 	weight = 5
 	earliest_start = 10 MINUTES
-	can_malf_fake_alert = TRUE
+	can_malf_fake_alert = TRUE //Austation addition
 
 /datum/round_event/disease_outbreak
 	announceWhen	= 15

--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -5,7 +5,7 @@
 	min_players = 5
 	weight = 20
 	alert_observers = 0
-	can_malf_fake_alert = TRUE
+	can_malf_fake_alert = TRUE //Austation addition 
 
 /datum/round_event/electrical_storm
 	var/lightsoutAmount	= 1

--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -5,6 +5,7 @@
 	min_players = 5
 	weight = 20
 	alert_observers = 0
+	can_malf_fake_alert = TRUE
 
 /datum/round_event/electrical_storm
 	var/lightsoutAmount	= 1

--- a/code/modules/events/space_dragon.dm
+++ b/code/modules/events/space_dragon.dm
@@ -7,7 +7,7 @@
 	min_players = 20
 	dynamic_should_hijack = TRUE
 	cannot_spawn_after_shuttlecall = TRUE
-	can_malf_fake_alert = TRUE
+	can_malf_fake_alert = TRUE //Austation addition
 
 /datum/round_event/ghost_role/space_dragon
 	minimum_required = 1

--- a/code/modules/events/space_dragon.dm
+++ b/code/modules/events/space_dragon.dm
@@ -7,6 +7,7 @@
 	min_players = 20
 	dynamic_should_hijack = TRUE
 	cannot_spawn_after_shuttlecall = TRUE
+	can_malf_fake_alert = TRUE
 
 /datum/round_event/ghost_role/space_dragon
 	minimum_required = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds 4 more alerts to the malf fake alert module to fake. I've given reasons in the individual commits

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Some of them synergize very well with other malf ai abilities/tactics, and the others are great for making people panic. It also has the added benefit of making those events less metable because you've got to wonder if the ai is just messing with you

## Changelog
:cl:
add: Added Communications Blackout to Malf Ai Fake Alert module
add: Added Disease outbreak to Malf Ai Fake Alert module
add: Added Electrical Storm to Malf Ai Fake Alert module
add: Added Space dragon to Malf Ai Fake Alert module
balance: Added 4 new alerts to the malf ai fake alert module
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
