### PR TITLE
Adds an igniter to the medical borg

### DIFF
--- a/austation/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/austation/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -384,3 +384,12 @@
 		else
 			return FALSE
 	return ..()
+
+
+
+
+####### Borg Inventory Changes #######
+/obj/item/robot_module/medical
+	emag_modules = list(
+		/obj/item/reagent_containers/borghypo/hacked,
+		/obj/item/assembly/igniter)

--- a/austation/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/austation/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -388,7 +388,7 @@
 
 
 
-####### Borg Inventory Changes #######
+ //Borg Inventory Changes 
 /obj/item/robot_module/medical
 	basic_modules = list(
 		/obj/item/assembly/flash/cyborg,

--- a/austation/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/austation/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -390,6 +390,26 @@
 
 ####### Borg Inventory Changes #######
 /obj/item/robot_module/medical
-	emag_modules = list(
-		/obj/item/reagent_containers/borghypo/hacked,
+	basic_modules = list(
+		/obj/item/assembly/flash/cyborg,
+		/obj/item/healthanalyzer,
+		/obj/item/borg/charger,
+		/obj/item/reagent_containers/borghypo,
+		/obj/item/borg/apparatus/beaker,
+		/obj/item/reagent_containers/dropper,
+		/obj/item/reagent_containers/syringe,
+		/obj/item/surgical_drapes,
+		/obj/item/retractor,
+		/obj/item/hemostat,
+		/obj/item/cautery,
+		/obj/item/surgicaldrill,
+		/obj/item/scalpel,
+		/obj/item/circular_saw,
+		/obj/item/blood_filter,
+		/obj/item/extinguisher/mini,
+		/obj/item/roller/robo,
+		/obj/item/borg/cyborghug/medical,
+		/obj/item/stack/medical/gauze/cyborg,
+		/obj/item/organ_storage,
+		/obj/item/borg/lollipop,
 		/obj/item/assembly/igniter)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Medical borg now gets an ignited

## Why It's Good For The Game

As a normal medical borg, it makes heater beakers much faster and possible to do even if someone has griefed the chemical heaters or power has run out (also makes it much less aggravating to make ash and charcoal)

Adding an igniter for antagonistic play will open up lots of interesting strategies for the medical borg instead of just injecting everyone and getting beat by those in a skinsuit.
With a mobile source of heat, you could: 
Splash napalm or oil onto your target and ignite them
Splash thermite onto a wall in order to get through
Use Stabilizing Agent and black powder to sacrifice a beaker and make a placeable explosion

TLDR: encourages creative plays.

## Changelog
:cl:
add: Added an igniter to the medical borg
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
