### PR TITLE
Flashes no long chain paralyse 

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -87,7 +87,7 @@
 	light_power = FLASH_LIGHT_POWER
 	var/flashing_overlay = "flash-f"
 	var/last_used = 0 //last world.time it was used.
-	var/cooldown = 20
+	var/cooldown = 100
 	var/last_trigger = 0 //Last time it was successfully triggered.
 	var/burnt_out = FALSE
 	var/obj/item/flashbulb/bulb = /obj/item/flashbulb	//Store reference to object and run new when initialised.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Increases flash cooldown time to 10 seconds.
You will only be able to flash once on a target, after their 7 seconds of paralyze are up, they can continue to fight back. Those seven seconds are still enough time to get some hits on, but flashes shouldn't be the all powerful meta

## Why It's Good For The Game

Prevents being chain stunned by flashes while still keeping the danger of being hit by them them.

POV: This is people complaining about this PR
![image](https://user-images.githubusercontent.com/60122079/127739101-2a9f008f-d2bc-46e4-8bab-e2b34e6737c9.png)


## Changelog
:cl:

balance: rebalanced something or other idon'tfucking know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
