### PR TITLE
RPEDs, bags and backpacks can now be emptied into disposal bins with a left-click

### DIFF
--- a/austation.dme
+++ b/austation.dme
@@ -254,6 +254,7 @@
 #include "austation\code\modules\reagents\reagent_containers\bottle.dm"
 #include "austation\code\modules\reagents\reagent_containers\custompen.dm"
 #include "austation\code\modules\reagents\reagent_containers\hypospray.dm"
+#include "austation\code\modules\recycling\disposal\bin.dm"
 #include "austation\code\modules\recycling\disposal\construction.dm"
 #include "austation\code\modules\recycling\disposal\holder.dm"
 #include "austation\code\modules\recycling\disposal\loafer.dm"

--- a/austation/code/modules/recycling/disposal/bin.dm
+++ b/austation/code/modules/recycling/disposal/bin.dm
@@ -11,9 +11,11 @@
 			B = I
 	if(!B || !length(B.contents))  //  It's not whitelisted or perhaps simply empty, so dispose of it like normal
 		return ..()
-
-	var/datum/component/storage/STR = B.GetComponent(/datum/component/storage)
-	user.visible_message("<span class='notice'>[user] empties \the [I] into \the [src].</span>", "<span class='warning'>You empty \the [I].</span>")
-	for(var/obj/item/O in B.contents)  //  O for Object(s)
-		STR.remove_from_storage(O,src)
-	B.update_icon()  //  We are overriding trash bags with this code, so we have to make sure they follow their routine.
+	user.visible_message("<span class='notice'>[user] empties \the [I] into \the [src].</span>", "<span class='warning'>You begin to empty \the [I] into \the [src].</span>")
+	if(!do_after(user, 10, src))
+		to_chat(user, "<span class='warning'>You stop emptying \the [I].</span>")
+	else
+		var/datum/component/storage/STR = B.GetComponent(/datum/component/storage)
+		for(var/obj/item/O in B.contents)  //  O for Object(s)
+			STR.remove_from_storage(O,src)
+		B.update_icon()  //  We are overriding trash bags with this code, so we have to make sure they follow their routine.

--- a/austation/code/modules/recycling/disposal/bin.dm
+++ b/austation/code/modules/recycling/disposal/bin.dm
@@ -1,15 +1,19 @@
-//  Lets us dump items straight into the bin from bags (botany bags were the main inspiration for this), saving the user a lot of time.
+//  Lets us dump items straight into the bin from bags and other storage items.  If the storage item is empty then we'll just pass it to the normal bin behaviour.
 /obj/machinery/disposal/bin/attackby(obj/item/I, mob/user, params)
 	var/obj/item/storage/B
-	if(istype(I, /obj/item/storage/bag) || istype(I, /obj/item/storage/backpack))
-		B = I
-	if(!B)
+	var/static/list/obj/item/storage/store_list = list(
+		/obj/item/storage/part_replacer,  //  RPEDs
+		/obj/item/storage/bag,			  //  Botany bags and serving trays etc
+		/obj/item/storage/backpack		  //  Backpacks
+	)
+	for(var/T in store_list)  //  T for Type, searching for types of storage item to whitelist, some like cardboard boxes are ignored.
+		if(istype(I, T))
+			B = I
+	if(!B || !length(B.contents))  //  It's not whitelisted or perhaps simply empty, so dispose of it like normal
 		return ..()
+
 	var/datum/component/storage/STR = B.GetComponent(/datum/component/storage)
-	if(!length(B.contents))
-		return ..()  //  Bins usually return like this if the item is not a trash bag.  We would still like to be able to throw out our bags if they are empty.
-	else
-		user.visible_message("<span class='notice'>[user] empties \the [I] into \the [src].</span>", "<span class='warning'>You empty \the [I].</span>")
-		for(var/obj/item/O in B.contents)
-			STR.remove_from_storage(O,src)
-		B.update_icon()  //  We are overriding trash bags with this code, so we have to make sure they follow their routine.
+	user.visible_message("<span class='notice'>[user] empties \the [I] into \the [src].</span>", "<span class='warning'>You empty \the [I].</span>")
+	for(var/obj/item/O in B.contents)  //  O for Object(s)
+		STR.remove_from_storage(O,src)
+	B.update_icon()  //  We are overriding trash bags with this code, so we have to make sure they follow their routine.

--- a/austation/code/modules/recycling/disposal/bin.dm
+++ b/austation/code/modules/recycling/disposal/bin.dm
@@ -1,0 +1,15 @@
+//  Lets us dump items straight into the bin from bags (botany bags were the main inspiration for this), saving the user a lot of time.
+/obj/machinery/disposal/bin/attackby(obj/item/I, mob/user, params)
+	var/obj/item/storage/B
+	if(istype(I, /obj/item/storage/bag) || istype(I, /obj/item/storage/backpack))
+		B = I
+	if(!B)
+		return ..()
+	var/datum/component/storage/STR = B.GetComponent(/datum/component/storage)
+	if(!length(B.contents))
+		return ..()  //  Bins usually return like this if the item is not a trash bag.  We would still like to be able to throw out our bags if they are empty.
+	else
+		user.visible_message("<span class='notice'>[user] empties \the [I] into \the [src].</span>", "<span class='warning'>You empty \the [I].</span>")
+		for(var/obj/item/O in B.contents)
+			STR.remove_from_storage(O,src)
+		B.update_icon()  //  We are overriding trash bags with this code, so we have to make sure they follow their routine.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
All bags and RPEDs now empty their contents into disposal bins with a left-click, the same way you would use a trash bag.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes housekeeping a lot simpler.

_I've been made aware since publishing this PR that the same action can already be done with a click-drag_
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Disposal bins now react to REPDs, bags and backpacks by emptying their contents instead of disposing the entire bag; Acts like normal if the bag was empty.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
