### PR TITLE
A Few Minor Mapping Changes 2.0

### DIFF
--- a/_maps/map_files/Austation/Austation.dmm
+++ b/_maps/map_files/Austation/Austation.dmm
@@ -4245,7 +4245,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/maintenance/department/cargo)
 "arL" = (
 /obj/effect/spawner/room/fivexthree,
 /turf/open/floor/plating,
@@ -10107,7 +10107,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/department/cargo)
 "aTa" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -29650,7 +29650,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
-/area/maintenance/port/fore)
+/area/maintenance/department/cargo)
 "cvE" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/white{
@@ -41488,7 +41488,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/maintenance/department/cargo)
 "ewV" = (
 /obj/machinery/light{
 	dir = 1
@@ -43492,7 +43492,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/maintenance/department/cargo)
 "fnZ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -47208,7 +47208,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/maintenance/department/cargo)
 "gTe" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -49022,20 +49022,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
-"hGc" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "hGj" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -50030,7 +50016,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/maintenance/department/cargo)
 "icG" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -50912,13 +50898,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
-"itz" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "itM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet/green,
@@ -51593,7 +51572,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/maintenance/department/cargo)
 "iJt" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Chemistry Lab Maintenance";
@@ -52103,6 +52082,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
+"iRZ" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "iSb" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -53284,7 +53275,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/maintenance/department/cargo)
 "jrV" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -54310,7 +54301,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/maintenance/port/fore)
+/area/maintenance/department/cargo)
 "jKF" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -58083,7 +58074,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/maintenance/department/cargo)
 "lqN" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -60029,7 +60020,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/maintenance/department/cargo)
 "mis" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -65651,7 +65642,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/maintenance/department/cargo)
 "opi" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -69072,6 +69063,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"pAu" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "pAS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -69761,7 +69766,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/maintenance/department/cargo)
 "pTG" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -72054,9 +72059,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"qQh" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/department/engine)
 "qQm" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -77596,6 +77598,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"tff" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/department/engine)
 "tfi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -78981,6 +78986,13 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
+"tGL" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "tGM" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -80449,7 +80461,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/maintenance/department/cargo)
 "ukn" = (
 /obj/machinery/camera{
 	c_tag = "Labor Shuttle Control Desk";
@@ -82011,7 +82023,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/maintenance/department/cargo)
 "uTx" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -85238,7 +85250,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/maintenance/department/cargo)
 "wdS" = (
 /obj/item/radio/intercom{
 	pixel_x = -28
@@ -87251,10 +87263,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable/yellow,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/maintenance/port/fore)
+/area/maintenance/department/cargo)
 "xbk" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -109990,9 +110004,9 @@ ayl
 ayl
 aHj
 iiL
-dne
+aFN
 mhE
-dne
+aQp
 pBO
 nay
 aQp
@@ -110249,7 +110263,7 @@ uVM
 ntE
 jrS
 uTk
-dne
+aQp
 uPh
 kDW
 aQq
@@ -110501,12 +110515,12 @@ dne
 dne
 dne
 dne
-dne
+aFN
 oqv
 aIt
-dne
+aFN
 pTb
-dne
+aQp
 imW
 oNd
 uep
@@ -110761,9 +110775,9 @@ aaa
 aFN
 nIb
 nIb
-dne
-sUo
-dne
+aFN
+iRZ
+aQp
 aNQ
 tIt
 aQs
@@ -111018,9 +111032,9 @@ aaf
 aFO
 uAW
 fHt
-dne
+aFN
 cvC
-dne
+aQp
 tSY
 vHn
 kSq
@@ -111275,18 +111289,18 @@ aaa
 aFP
 oVI
 lYT
-dne
-sUo
-dne
-dne
-dne
-dne
-dne
-dne
-dne
-dne
-dne
-dne
+aFN
+iRZ
+aQp
+aQp
+aQp
+aQp
+aQp
+aSX
+aSX
+aSX
+aSX
+aSX
 hCy
 ygK
 bbY
@@ -111543,7 +111557,7 @@ opf
 fnW
 fnW
 xaa
-dne
+baE
 baB
 emA
 bbY
@@ -112057,7 +112071,7 @@ aTa
 dhL
 aJN
 gTa
-dne
+baE
 baD
 bca
 bdv
@@ -112314,7 +112328,7 @@ aTb
 aUo
 aJN
 lqi
-dne
+baE
 baE
 baE
 bdw
@@ -115361,7 +115375,7 @@ sIs
 noJ
 dIA
 hqf
-hGc
+pAu
 dzP
 agL
 ahz
@@ -133386,12 +133400,12 @@ djt
 dfG
 roT
 vsR
-itz
+tGL
 bif
 dgo
 bif
 cXZ
-qQh
+tff
 bfZ
 bif
 bfY
@@ -133643,12 +133657,12 @@ djx
 dfG
 cXz
 vsR
-qQh
+tff
 bie
 dgp
 cXI
 cYj
-qQh
+tff
 wOY
 adF
 wOY
@@ -133904,8 +133918,8 @@ dgd
 dgj
 dgp
 bie
-qQh
-qQh
+tff
+tff
 aaa
 aaa
 aaa

--- a/_maps/map_files/Austation/Austation.dmm
+++ b/_maps/map_files/Austation/Austation.dmm
@@ -2966,10 +2966,6 @@
 "alq" = (
 /turf/closed/wall,
 /area/maintenance/starboard)
-"alr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "als" = (
 /obj/machinery/light{
 	dir = 8
@@ -13438,14 +13434,14 @@
 	anchored = 1
 	},
 /turf/open/floor/plating,
-/area/engine/break_room)
+/area/maintenance/department/engine)
 "bfZ" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/item/kirbyplants/random,
 /turf/open/floor/plating,
-/area/engine/break_room)
+/area/maintenance/department/engine)
 "bgc" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Space Access Airlock";
@@ -13983,10 +13979,10 @@
 "bie" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/engine/break_room)
+/area/maintenance/department/engine)
 "bif" = (
 /turf/open/floor/plating,
-/area/engine/break_room)
+/area/maintenance/department/engine)
 "bii" = (
 /obj/docking_port/stationary/random{
 	dir = 4;
@@ -31151,8 +31147,11 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/maintenance/department/engine)
 "cCd" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /turf/open/floor/plasteel/white/corner{
@@ -35599,19 +35598,20 @@
 "cXI" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/engine)
 "cXT" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
 "cXZ" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/engine)
 "cYa" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -35663,7 +35663,7 @@
 /obj/structure/closet/firecloset,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/engine)
 "cYm" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -37458,7 +37458,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/engine)
 "dgd" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space,
@@ -37516,14 +37516,14 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/engine)
 "dgp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/engine)
 "dgq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
@@ -38377,8 +38377,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/engine)
 "dlG" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -45692,9 +45695,6 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
 "glZ" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/machinery/holopad,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -45704,6 +45704,12 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -46065,7 +46071,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/engine)
 "gxF" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -49016,6 +49022,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
+"hGc" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "hGj" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -50892,6 +50912,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"itz" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "itM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet/green,
@@ -52595,7 +52622,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/engine)
 "jdT" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -58727,20 +58754,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/carpet/royalblack,
 /area/engine/engineering/reactor_control)
-"lGl" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "lGq" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -59157,10 +59170,13 @@
 "lOR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
-/area/maintenance/starboard)
+/area/maintenance/department/engine)
 "lOY" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -61170,7 +61186,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/engine)
 "mHl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -69065,7 +69081,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/engine)
 "pBH" = (
 /obj/structure/rack,
 /obj/item/tank/internals/air,
@@ -72038,6 +72054,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
+"qQh" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/department/engine)
 "qQm" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -75307,7 +75326,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/engine)
 "sij" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -76090,6 +76109,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -77108,8 +77130,11 @@
 "sVg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
-/area/engine/break_room)
+/area/maintenance/department/engine)
 "sVK" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/purple{
@@ -83854,8 +83879,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plating,
-/area/engine/break_room)
+/area/maintenance/department/engine)
 "vHn" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
@@ -115333,7 +115361,7 @@ sIs
 noJ
 dIA
 hqf
-lGl
+hGc
 dzP
 agL
 ahz
@@ -132073,7 +132101,7 @@ deB
 aSz
 aTM
 vsR
-apc
+bif
 aYu
 aZL
 urz
@@ -132330,7 +132358,7 @@ dBA
 aSA
 aTN
 gxD
-apc
+bif
 aYu
 aZM
 hyV
@@ -132587,7 +132615,7 @@ aRv
 dfD
 oZr
 tDX
-apc
+bif
 aYu
 aZN
 mrh
@@ -133358,12 +133386,12 @@ djt
 dfG
 roT
 vsR
-apc
-apc
+itz
+bif
 dgo
-apc
+bif
 cXZ
-atm
+qQh
 bfZ
 bif
 bfY
@@ -133615,12 +133643,12 @@ djx
 dfG
 cXz
 vsR
-atm
-alr
+qQh
+bie
 dgp
 cXI
 cYj
-atm
+qQh
 wOY
 adF
 wOY
@@ -133875,9 +133903,9 @@ ifb
 dgd
 dgj
 dgp
-alr
-atm
-atm
+bie
+qQh
+qQh
 aaa
 aaa
 aaa

--- a/_maps/map_files/Austation/Austation.dmm
+++ b/_maps/map_files/Austation/Austation.dmm
@@ -41403,6 +41403,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"eun" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "evA" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/landmark/nuclear_waste_spawner,
@@ -52082,18 +52094,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
-"iRZ" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "iSb" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -54086,6 +54086,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"jFn" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "jFX" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -54297,6 +54304,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -69063,20 +69074,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"pAu" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "pAS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -72812,6 +72809,20 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
+"reW" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "rfc" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -77598,9 +77609,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"tff" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/department/engine)
 "tfi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -78986,13 +78994,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
-"tGL" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "tGM" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -80782,6 +80783,9 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
+"upT" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/department/engine)
 "upW" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -87263,8 +87267,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable/yellow,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -110776,7 +110778,7 @@ aFN
 nIb
 nIb
 aFN
-iRZ
+eun
 aQp
 aNQ
 tIt
@@ -111290,7 +111292,7 @@ aFP
 oVI
 lYT
 aFN
-iRZ
+eun
 aQp
 aQp
 aQp
@@ -115375,7 +115377,7 @@ sIs
 noJ
 dIA
 hqf
-pAu
+reW
 dzP
 agL
 ahz
@@ -133400,12 +133402,12 @@ djt
 dfG
 roT
 vsR
-tGL
+jFn
 bif
 dgo
 bif
 cXZ
-tff
+upT
 bfZ
 bif
 bfY
@@ -133657,12 +133659,12 @@ djx
 dfG
 cXz
 vsR
-tff
+upT
 bie
 dgp
 cXI
 cYj
-tff
+upT
 wOY
 adF
 wOY
@@ -133918,8 +133920,8 @@ dgd
 dgj
 dgp
 bie
-tff
-tff
+upT
+upT
 aaa
 aaa
 aaa

--- a/_maps/map_files/Austation/Austation.dmm
+++ b/_maps/map_files/Austation/Austation.dmm
@@ -40216,6 +40216,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"dOP" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "dPg" = (
 /obj/machinery/light{
 	dir = 8
@@ -40760,6 +40774,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"ebP" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/department/engine)
 "eca" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -41403,18 +41420,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"eun" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "evA" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/landmark/nuclear_waste_spawner,
@@ -46306,6 +46311,9 @@
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "SciLoad"
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/science/shuttledock)
@@ -52368,6 +52376,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
+"iYe" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "iYB" = (
 /obj/item/beacon,
 /obj/effect/turf_decal/stripes/line{
@@ -54086,13 +54106,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"jFn" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "jFX" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -71152,6 +71165,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"qyu" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "qyF" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Long-Term Cell 2";
@@ -72809,20 +72829,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
-"reW" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "rfc" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -80783,9 +80789,6 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
-"upT" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/department/engine)
 "upW" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -110778,7 +110781,7 @@ aFN
 nIb
 nIb
 aFN
-eun
+iYe
 aQp
 aNQ
 tIt
@@ -111292,7 +111295,7 @@ aFP
 oVI
 lYT
 aFN
-eun
+iYe
 aQp
 aQp
 aQp
@@ -115377,7 +115380,7 @@ sIs
 noJ
 dIA
 hqf
-reW
+dOP
 dzP
 agL
 ahz
@@ -133402,12 +133405,12 @@ djt
 dfG
 roT
 vsR
-jFn
+qyu
 bif
 dgo
 bif
 cXZ
-upT
+ebP
 bfZ
 bif
 bfY
@@ -133659,12 +133662,12 @@ djx
 dfG
 cXz
 vsR
-upT
+ebP
 bie
 dgp
 cXI
 cYj
-upT
+ebP
 wOY
 adF
 wOY
@@ -133920,8 +133923,8 @@ dgd
 dgj
 dgp
 bie
-upT
-upT
+ebP
+ebP
 aaa
 aaa
 aaa

--- a/_maps/map_files/Austation/Austation.dmm
+++ b/_maps/map_files/Austation/Austation.dmm
@@ -2156,7 +2156,7 @@
 "ahT" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold{
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -42924,9 +42924,6 @@
 "fcl" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/three,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -46281,6 +46278,9 @@
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "SciLoad"
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/science/shuttledock)
@@ -53022,12 +53022,12 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/machinery/light/broken{
-	dir = 8
-	},
 /obj/structure/closet/crate/radiation,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
@@ -57161,6 +57161,9 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
@@ -68637,11 +68640,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "ptD" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Toxins - Lab";
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
@@ -76611,6 +76615,10 @@
 	},
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
+/obj/machinery/camera{
+	c_tag = "Service Lathe";
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "sMO" = (
@@ -77107,6 +77115,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
+/obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "sWP" = (
@@ -77987,6 +77996,9 @@
 /area/maintenance/starboard/fore)
 "toE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/science/shuttledock)
 "toJ" = (
@@ -87419,6 +87431,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
 "xht" = (

--- a/_maps/map_files/Austation/Austation.dmm
+++ b/_maps/map_files/Austation/Austation.dmm
@@ -555,18 +555,18 @@
 /area/security/prison)
 "abL" = (
 /turf/open/floor/plating,
-/area/security/prison)
+/area/maintenance/department/security/brig)
 "abM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/security/prison)
+/area/maintenance/department/security/brig)
 "abN" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
-/area/security/prison)
+/area/maintenance/department/security/brig)
 "abO" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -698,7 +698,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
-/area/security/prison)
+/area/maintenance/department/security/brig)
 "acq" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets{
@@ -26006,8 +26006,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
-/area/security/prison)
+/area/maintenance/department/security/brig)
 "cgR" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -27152,8 +27155,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/light/small,
 /turf/open/floor/plating,
-/area/security/prison)
+/area/maintenance/department/security/brig)
 "cmb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -38917,7 +38921,7 @@
 	dir = 4
 	},
 /turf/closed/wall,
-/area/security/prison)
+/area/maintenance/department/security/brig)
 "dtM" = (
 /obj/effect/turf_decal/bot,
 /obj/item/kirbyplants/random,
@@ -38944,8 +38948,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
-/area/security/prison)
+/area/maintenance/department/security/brig)
 "duo" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -39123,7 +39130,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/security/prison)
+/area/maintenance/department/security/brig)
 "dyb" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -39953,8 +39960,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
-/area/security/prison)
+/area/maintenance/department/security/brig)
 "dII" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -41421,7 +41431,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/security/prison)
+/area/maintenance/department/security/brig)
 "ewi" = (
 /obj/machinery/door/airlock/security{
 	name = "Interrogation Monitoring";
@@ -46279,9 +46289,6 @@
 	dir = 8;
 	id = "SciLoad"
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/science/shuttledock)
 "gDA" = (
@@ -48357,8 +48364,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
-/area/security/prison)
+/area/maintenance/department/security/brig)
 "hqp" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -49630,7 +49640,7 @@
 	dir = 8
 	},
 /turf/closed/wall,
-/area/security/prison)
+/area/maintenance/department/security/brig)
 "hTA" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -53764,8 +53774,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plating,
-/area/security/prison)
+/area/maintenance/department/security/brig)
 "jAw" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -58714,6 +58727,20 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/carpet/royalblack,
 /area/engine/engineering/reactor_control)
+"lGl" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "lGq" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -60908,17 +60935,24 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "mBD" = (
-/obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/department/security/brig";
+	name = "Prison Wing Maintenance APC";
+	pixel_y = -24
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/security/prison)
+/area/maintenance/department/security/brig)
 "mBS" = (
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/tile/purple{
@@ -62787,10 +62821,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
-/area/security/prison)
+/area/maintenance/department/security/brig)
 "noS" = (
 /obj/structure/chair{
 	dir = 1
@@ -67706,7 +67743,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/security/prison)
+/area/maintenance/department/security/brig)
 "pcQ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -75140,7 +75177,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/plating,
-/area/security/prison)
+/area/maintenance/department/security/brig)
 "sgb" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -75851,7 +75888,7 @@
 	dir = 6
 	},
 /turf/closed/wall,
-/area/security/prison)
+/area/maintenance/department/security/brig)
 "swz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -76407,8 +76444,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
-/area/security/prison)
+/area/maintenance/department/security/brig)
 "sIt" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/item/radio/intercom{
@@ -81856,7 +81896,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/security/prison)
+/area/maintenance/department/security/brig)
 "uRo" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -86096,7 +86136,7 @@
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
-/area/security/prison)
+/area/maintenance/department/security/brig)
 "wCh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -115293,7 +115333,7 @@ sIs
 noJ
 dIA
 hqf
-uVH
+lGl
 dzP
 agL
 ahz


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reopens #3995 

Fixes a number of background things around the austation.dmm map

- Remaps prison wing maintenance as a true maintenance area, protecting it from rad storms. Also the perma toilet to this area, giving prisoners a place to shelter from storms.
![image](https://user-images.githubusercontent.com/54165560/129495320-d0e7641b-18ec-4376-899a-696caa58d15d.png)
![image](https://user-images.githubusercontent.com/54165560/129495349-9016d5f1-bf22-4966-840e-60e6189fc951.png)

- Adds a camera to the service lathe, allowing the ai to open and close the doors for those without access
![image](https://user-images.githubusercontent.com/54165560/129495508-75305d31-5122-43e0-8799-f624f7ba790c.png)

- Adds a camera to the science shuttle dock, and revamps the lights
![image](https://user-images.githubusercontent.com/54165560/129495535-d1b4d5c8-757c-4882-9a25-a887f7d1a98f.png)

- Adds a light to starboard aft solar and grav gen atrium 
![image](https://user-images.githubusercontent.com/54165560/129495553-bf6ce0b9-73c1-4b07-8c8a-15e4f1371691.png)
![image](https://user-images.githubusercontent.com/54165560/129495562-8e87b22b-bf20-46b8-98db-e11268bb0641.png)

- Fixes a manifold in the incinerator spawning under the tile
 ![image](https://user-images.githubusercontent.com/54165560/129495584-eb220d3a-0ea6-47f7-a304-9394fcb15376.png)

- Separates Engineering maints from starboard maints, giving it its own APC
![image](https://user-images.githubusercontent.com/54165560/129495635-933186e3-f035-43cc-b3c8-c5c8d6b4591d.png)

- Separates Cargo maints from port aft maints, giving it its own APC
![image](https://user-images.githubusercontent.com/54165560/129495667-7beaa4d7-59e1-42dd-b06f-ee7be508552b.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Combines a number of mapping changes into one big pr. Mostly minor quality of life changes, with the prison wing maintenance update being the most game impacting portion.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Remapped the prison wing maintenance to be a true maintenance, giving it radiation storm protection. Also included the perma toilet for prisoner protection.
add: a few lights and cameras for quality of life
tweak: Seperated cargo maints from port bow maints, and engineering maints from starboard maints
fix: incinerator manifold under tile
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
