### PR TITLE
Explorer Comms and Toxin Path

### DIFF
--- a/_maps/map_files/Austation/Austation.dmm
+++ b/_maps/map_files/Austation/Austation.dmm
@@ -15545,10 +15545,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"bpr" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "bpt" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/effect/turf_decal/tile/red,
@@ -17484,9 +17480,12 @@
 /area/tcommsat/computer)
 "bzv" = (
 /obj/structure/window/reinforced{
-	dir = 4
+	dir = 1;
+	layer = 2.9
 	},
-/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bzx" = (
@@ -21124,7 +21123,7 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "bOc" = (
-/obj/machinery/telecomms/broadcaster/preset_left,
+/obj/machinery/telecomms/bus/preset_exploration,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "bOd" = (
@@ -22851,7 +22850,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "bUL" = (
-/obj/machinery/telecomms/server/presets/security,
+/obj/machinery/telecomms/receiver/preset_exploration,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "bUY" = (
@@ -25377,7 +25376,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "ceC" = (
-/obj/machinery/telecomms/server/presets/command,
+/obj/machinery/telecomms/hub/preset/exploration,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "ceF" = (
@@ -25947,7 +25946,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "cgy" = (
-/obj/machinery/telecomms/server/presets/service,
+/obj/machinery/telecomms/broadcaster/preset_exploration,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "cgz" = (
@@ -26191,11 +26190,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "chn" = (
-/obj/machinery/telecomms/broadcaster/preset_right,
+/obj/machinery/telecomms/processor/preset_exploration,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "cho" = (
-/obj/machinery/telecomms/server/presets/supply,
+/obj/machinery/telecomms/relay/preset/exploration,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "chp" = (
@@ -27381,8 +27380,23 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cmX" = (
-/obj/structure/window/reinforced,
-/obj/machinery/holopad,
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "MiniSat Exterior - Aft";
+	network = list("minisat")
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "cne" = (
@@ -28024,9 +28038,12 @@
 /area/maintenance/disposal/incinerator)
 "cpO" = (
 /obj/structure/window/reinforced{
-	dir = 8
+	dir = 1;
+	layer = 2.9
 	},
-/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "cpP" = (
@@ -30841,7 +30858,7 @@
 	},
 /obj/machinery/door/airlock/research{
 	name = "Toxins Lab";
-	req_access_txt = "8"
+	req_one_access_txt = "8; 49"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "toxins_blastdoor";
@@ -42059,15 +42076,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "eGd" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
-/turf/open/space,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/closed/wall,
 /area/aisat)
 "eGe" = (
 /obj/effect/spawner/structure/window,
@@ -46147,11 +46162,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "gyC" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
@@ -46428,7 +46443,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
-/area/science/misc_lab/range)
+/area/maintenance/department/science)
 "gEK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -48844,6 +48859,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
+"hBv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "hCd" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -49218,6 +49242,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"hJS" = (
+/obj/structure/chair,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "hJT" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -49909,6 +49940,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"hZn" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "hZI" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -52283,16 +52325,9 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "iUl" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
+/obj/machinery/telecomms/broadcaster/preset_left,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "iUp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -52500,6 +52535,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
@@ -52862,6 +52900,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/genetics)
+"jkb" = (
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "jkr" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -53672,15 +53714,9 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "jxx" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
+/obj/machinery/telecomms/server/presets/command,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "jxN" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -54132,12 +54168,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "jGA" = (
-/obj/structure/chair,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
+/obj/machinery/telecomms/server/presets/security,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "jGC" = (
 /obj/item/assembly/prox_sensor,
 /obj/structure/cable/yellow{
@@ -54330,24 +54363,14 @@
 	},
 /area/maintenance/department/cargo)
 "jKF" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/machinery/light/small{
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "MiniSat Exterior - Aft";
-	network = list("minisat")
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/space,
 /area/aisat)
 "jLc" = (
 /obj/structure/chair/stool,
@@ -55062,14 +55085,17 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "kcT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
 	},
-/turf/closed/wall/r_wall,
-/area/aisat)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/tcommsat/server)
 "kcU" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -57120,7 +57146,7 @@
 	},
 /obj/machinery/door/airlock/research{
 	name = "Experimentation Lab";
-	req_access_txt = "8"
+	req_access_txt = "47"
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -58798,15 +58824,9 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "lGC" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
+/obj/machinery/telecomms/server/presets/service,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "lGS" = (
 /obj/docking_port/stationary/public_mining_dock,
 /turf/open/floor/plating,
@@ -60165,6 +60185,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"mnh" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "mnJ" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -60453,6 +60480,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
+"msy" = (
+/obj/structure/chair,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "msz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64228,15 +64262,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "nPw" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
+/obj/machinery/telecomms/server/presets/supply,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "nPC" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/bar,
@@ -67146,13 +67174,15 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "oTj" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/space,
 /area/aisat)
 "oTr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -68183,7 +68213,7 @@
 "pjR" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Experimentation Lab Maintenance";
-	req_access_txt = "8"
+	req_access_txt = "47"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -68617,6 +68647,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"psj" = (
+/obj/structure/window/reinforced,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "psm" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -72356,14 +72391,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "qWs" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
-/turf/open/space,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/turf/closed/wall/r_wall,
 /area/aisat)
 "qWD" = (
 /obj/machinery/holopad,
@@ -74566,7 +74600,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
-/area/science/mixing)
+/area/maintenance/department/science)
 "rSL" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
@@ -76315,7 +76349,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;47"
+	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
@@ -81452,7 +81488,7 @@
 "uIN" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Launch Room Access";
-	req_access_txt = "8"
+	req_one_access_txt = "8; 49"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "toxins_blastdoor";
@@ -82200,14 +82236,17 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "uWP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 1
+/obj/machinery/light/small,
+/obj/machinery/camera{
+	c_tag = "Telecomms - Server Room - Aft";
+	dir = 1;
+	network = list("ss13","tcomms")
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/turf/closed/wall,
-/area/aisat)
+/obj/machinery/ntnet_relay,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/tcommsat/server)
 "uXd" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -83224,6 +83263,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"vsG" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "vsK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
@@ -83938,15 +83987,13 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "vIa" = (
-/obj/machinery/light/small,
-/obj/machinery/camera{
-	c_tag = "Telecomms - Server Room - Aft";
-	dir = 1;
-	network = list("ss13","tcomms")
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 1
 	},
-/obj/machinery/ntnet_relay,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "vIt" = (
@@ -87745,12 +87792,9 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "xlJ" = (
-/obj/structure/chair,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
+/obj/machinery/telecomms/broadcaster/preset_right,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "xmG" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -88199,6 +88243,13 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"xvo" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "xwm" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -142671,8 +142722,8 @@ anT
 anT
 anT
 anT
-aaa
-aaa
+anT
+anT
 aaa
 aaa
 aaa
@@ -142921,6 +142972,8 @@ aNw
 aNw
 aNw
 aNw
+aNw
+aNw
 bJl
 aNw
 aNw
@@ -142928,8 +142981,6 @@ aNw
 aTQ
 aaa
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -143180,13 +143231,13 @@ bMt
 bMt
 bMt
 bMt
+bMt
+bMt
 aOT
 aOT
 xTn
 bBb
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -143438,12 +143489,12 @@ aOY
 aOY
 aOY
 aOY
+aOY
+aOY
 bcQ
 sAV
 bgn
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -143695,12 +143746,12 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aMq
 sAV
 bgn
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -143949,6 +144000,8 @@ aRy
 aRy
 bvt
 bvt
+bvt
+bvt
 aaa
 aaa
 aaa
@@ -143956,8 +144009,6 @@ aMq
 sAV
 bgn
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -144207,16 +144258,16 @@ aRy
 aRy
 aRy
 aRy
+aRy
+aRy
 aaa
 aaa
 aMq
-iUl
+hZn
 bBb
 anT
 anT
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -144461,19 +144512,19 @@ bGd
 bGd
 bJm
 bNX
-bMo
+bGd
 bOc
+bMo
+iUl
 aRy
 aaa
 aaa
 aMq
-iUl
+hZn
 bAT
 aNw
 aaa
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -144720,17 +144771,17 @@ bKL
 bNY
 bGd
 ceC
+bGd
+jxx
 aRy
 bvt
 aaa
 aMq
-nPw
-bpn
 cpO
+bpn
+mnh
 bgn
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -144977,17 +145028,17 @@ vFk
 vFk
 seF
 bUL
+bGd
+jGA
 aRy
 bvt
 aaa
 aMq
-nPw
-xlJ
-bpr
+cpO
+msy
+jkb
 bgn
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -145241,10 +145292,10 @@ eGd
 jKF
 oTj
 cmX
+hBv
+psj
 bgn
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -145491,17 +145542,17 @@ gwL
 gwL
 gyC
 cgy
+bMr
+lGC
 aRy
 bvt
 aaa
 aMq
-lGC
-jGA
-bpr
+bzv
+hJS
+jkb
 bgn
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -145746,19 +145797,19 @@ bGe
 bGd
 bKP
 bOb
-bMr
+bGd
 cho
+bMr
+nPw
 aRy
 bvt
 aaa
 aMq
-lGC
-bpq
 bzv
+bpq
+xvo
 bgn
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -146003,8 +146054,10 @@ bGd
 bGd
 bKN
 bOa
-bMs
+bGd
 chn
+bMs
+xlJ
 aRy
 aaa
 aaa
@@ -146014,8 +146067,6 @@ aVk
 aOY
 aaa
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -146263,6 +146314,8 @@ aRy
 aRy
 aRy
 aRy
+aRy
+aRy
 aaa
 aaa
 aMq
@@ -146271,8 +146324,6 @@ bBb
 anT
 anT
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -146519,6 +146570,8 @@ aRy
 aRy
 bvt
 bvt
+bvt
+bvt
 aaa
 aaa
 aaa
@@ -146526,8 +146579,6 @@ aMq
 puf
 bgn
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -146779,12 +146830,12 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aMq
 puf
 bgn
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -147036,12 +147087,12 @@ aNw
 aNw
 aNw
 aNw
+aNw
+aNw
 bly
 puf
 bgn
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -147294,11 +147345,11 @@ bMt
 bMt
 bMt
 bMt
-jxx
+bMt
+bMt
+vsG
 bBb
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -147548,14 +147599,14 @@ aNC
 aOY
 aOY
 aOY
+aNC
+aOY
 aOY
 aOY
 aOY
 aNC
 aaa
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -147811,8 +147862,8 @@ anT
 anT
 anT
 anT
-aaa
-aaa
+anT
+anT
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds all the communication devices required for explorers comms channel. Also adds explorer access to the left and right doors to toxins, allowing explorers to avoid the walk through maints.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Explorer channel doesn't work, this fixes it 
![image](https://user-images.githubusercontent.com/54165560/132114831-3f55089d-7ee7-4c6f-b539-8a1fa0ec91b6.png)

Walking through maints to reach your job is bad (shut up janitor mains, you'll get a new room eventually). Only the left and right doors get access, so explorers can't just walk in and steal the plasma cannisters from toxin storage.
![image](https://user-images.githubusercontent.com/54165560/132114887-75d6b7a9-145d-402f-b7aa-2d3b5bf907a7.png)


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: infrastructure for explorers comms channel
tweak: explorer access to left and right doors of toxins
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
