### PR TITLE
[WIP] Sentient Disease point economy rebalance

### DIFF
--- a/austation/code/modules/antagonists/disease/disease_abilities.dm
+++ b/austation/code/modules/antagonists/disease/disease_abilities.dm
@@ -1,0 +1,22 @@
+/datum/disease_ability/action/sneeze
+	cost = 1
+
+/datum/disease_ability/action/infect
+	cost = 1
+
+/datum/disease_ability/symptom/mild
+	cost = 1
+	required_total_points = 2
+
+/datum/disease_ability/symptom/medium
+	cost = 2
+	required_total_points = 4
+
+/datum/disease_ability/symptom/medium/heal
+	cost = 3
+
+/datum/disease_ability/symptom/powerful
+	required_total_points = 8
+
+/datum/disease_ability/symptom/powerful/heal
+	cost = 4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Rebalances all sentient disease powers to be more accessible, earlier into the game.
This has been done to ensure that diseases get access to more of their powers within the scope of AuStation, where pop expectations are much lower than on Beestation.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Sentient Diseases are a very frustrating antag to play because they rarely get access to any of their more interesting abilities.  This has the knock-on effect that they are uninteresting for the crew to encounter as well, because they only ever face diseases with the sparse few symptoms from the beginning of the list.
Sentient Diseases face this problem because of two issues in particular:
1) Their cost requirements are catered towards servers that experience larger, denser populations than the environment here at austation.
2) Sentient Diseases are often stomped out very quickly, due to both the lack of positive abilities available at the start of the list, that might encourage the crew to keep it, but also because of the lack of powerful offensive and defensive options that would allow it to put up a better fight.

If Sentient Diseases were to be given more leeway on Austation, allowed to be buffed to a stronger early game than on other stations, then I believe we would find an equilibrium in which Sentient Diseases have the intended impact on our games.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Sentient disease - costs halved for most symptoms
tweak: Sentient disease - total required points halved for most symptoms
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
