### PR TITLE
removes clown access requirement from the rear stage maint door

### DIFF
--- a/_maps/map_files/Austation/Austation.dmm
+++ b/_maps/map_files/Austation/Austation.dmm
@@ -46413,7 +46413,7 @@
 "gEs" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Stage";
-	req_one_access_txt = "12;46"
+	req_one_access_txt = "12"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Everyone hates this door.
The stage is not a restricted area, so it doesn't make sense that you need clown access to go through that door.
Everyone hates this door.

![image](https://user-images.githubusercontent.com/23044898/134792129-b27a130a-0e1e-4abc-ad5d-acd3f72c6ba4.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Theatre Stage door no longer requires access 46 (theatre)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
