### PR TITLE
idk apparently recipe for gasoline/petrol can't be done

### DIFF
--- a/austation/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/austation/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -77,4 +77,4 @@
 	id = /datum/reagent/gasoline
 	results = list(/datum/reagent/gasoline = 3)
 	required_reagents = list(/datum/reagent/oil = 1, /datum/reagent/fuel = 1)
-	required_temp = 613
+	required_temp = 450

--- a/austation/code/modules/reagents/reagent_containers/glass.dm
+++ b/austation/code/modules/reagents/reagent_containers/glass.dm
@@ -3,8 +3,7 @@
 	desc = "A large plastic fuel can. Holds up to 150 units."
 	icon = 'austation/icons/obj/chemical.dmi'
 	icon_state = "jerry"
-	spillable = FALSE
-	materials = list(/datum/material/glass=3000, /datum/material/plastic=3000)
+	materials = list(/datum/material/glass=500, /datum/material/plastic=3000)
 	volume = 150
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,150)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
i dunno
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
can actually make gasoline/petrol now
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:YakiAttaki
fix: fixed recipe for gasoline/petrol
fix: you can now transfer that sweet, sweet gasoline/petrol from a jerry can to a beaker
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
