### PR TITLE
rats leave mouse corpses instead of being deleted.

### DIFF
--- a/austation/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/austation/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -95,7 +95,6 @@
 	.=..()
 	if(!.)
 		return
-
 	for(var/mob/living/M in oview(owner,1))
 		M.faction += list("rat")
 		owner.visible_message("<span class='notice'>[M] was made an ally to the rats!</span>")
@@ -288,6 +287,14 @@
 				playsound(src, 'sound/effects/sparks2.ogg', 100, TRUE)
 				C.deconstruct()
 
-/mob/living/simple_animal/hostile/rat/death()
+/mob/living/simple_animal/hostile/rat/death(gibbed)
 	visible_message("<span class='warning'>[src] dies...</span>")
-	// qdel(src)  austation "rats die right" (#4285)
+	if(!ckey)
+		if(!gibbed)
+			var/obj/item/reagent_containers/food/snacks/deadmouse/M = new(loc)
+			M.icon_state = icon_dead
+			M.name = name
+			M.reagents.add_reagent(/datum/reagent/blood, 2, data)
+			qdel(src)
+	else
+		..(gibbed)

--- a/austation/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/austation/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -289,6 +289,7 @@
 
 /mob/living/simple_animal/hostile/rat/death(gibbed)
 	visible_message("<span class='warning'>[src] dies...</span>")
+	var/list/data = list("viruses" = ratdisease)
 	if(!ckey)
 		if(!gibbed)
 			var/obj/item/reagent_containers/food/snacks/deadmouse/M = new(loc)

--- a/austation/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/austation/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -229,10 +229,15 @@
 	mob_size = MOB_SIZE_TINY
 	mob_biotypes = list(MOB_ORGANIC,MOB_BEAST)
 	faction = list("rat")
+	var/list/ratdisease = list()
 
 /mob/living/simple_animal/hostile/rat/Initialize()
 	. = ..()
 	SSmobs.cheeserats += src
+	if(prob(75))
+		var/datum/disease/advance/R = new /datum/disease/advance/random(rand(3, 6), 9, rand(3,4))
+		R.spread_flags |= DISEASE_SPREAD_CHECK_STRONG_STOMACH // austation -- make catgirls and lizards immune to diseases from rats
+		ratdisease += R
 
 /mob/living/simple_animal/hostile/rat/Destroy()
 	SSmobs.cheeserats -= src

--- a/austation/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/austation/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -95,7 +95,7 @@
 	.=..()
 	if(!.)
 		return
-		
+
 	for(var/mob/living/M in oview(owner,1))
 		M.faction += list("rat")
 		owner.visible_message("<span class='notice'>[M] was made an ally to the rats!</span>")
@@ -290,4 +290,4 @@
 
 /mob/living/simple_animal/hostile/rat/death()
 	visible_message("<span class='warning'>[src] dies...</span>")
-	qdel(src)
+	// qdel(src)  austation "rats die right" (#4285)

--- a/austation/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/austation/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -236,7 +236,7 @@
 	SSmobs.cheeserats += src
 	if(prob(75))
 		var/datum/disease/advance/R = new /datum/disease/advance/random(rand(3, 6), 9, rand(3,4))
-		R.spread_flags |= DISEASE_SPREAD_CHECK_STRONG_STOMACH // austation -- make catgirls and lizards immune to diseases from rats
+		R.spread_flags |= DISEASE_SPREAD_CHECK_STRONG_STOMACH
 		ratdisease += R
 
 /mob/living/simple_animal/hostile/rat/Destroy()

--- a/austation/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/austation/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -303,4 +303,4 @@
 			M.reagents.add_reagent(/datum/reagent/blood, 2, data)
 			qdel(src)
 	else
-		..(gibbed)
+		qdel(src)

--- a/austation/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/austation/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -303,4 +303,4 @@
 			M.reagents.add_reagent(/datum/reagent/blood, 2, data)
 			qdel(src)
 	else
-		qdel(src)
+		..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Rats now leave a corpse when they die, meaning they can be made into rat-burgers

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Rats leaving no corpse was a little immersion breaking.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: rats are not deleted on death
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
