### PR TITLE
adds a pref to typing indicators

### DIFF
--- a/austation.dme
+++ b/austation.dme
@@ -24,6 +24,7 @@
 #include "austation\code\__DEFINES\RPD.dm"
 #include "austation\code\__DEFINES\sound.dm"
 #include "austation\code\__DEFINES\traits.dm"
+#include "austation\code\__DEFINES\preferences.dm"
 // END_DEFINE_INCLUDE
 
 // BEGIN_BEESTATION_INCLUDE
@@ -209,6 +210,7 @@
 #include "austation\code\modules\mining\lavaland\necropolis_chests.dm"
 #include "austation\code\modules\mob\mob.dm"
 #include "austation\code\modules\mob\mob_defines.dm"
+#include "austation\code\modules\mob\typing_indicator.dm"
 #include "austation\code\modules\mob\dead\new_player\new_player.dm"
 #include "austation\code\modules\mob\living\emote.dm"
 #include "austation\code\modules\mob\living\pseudo_z_axis.dm"

--- a/austation/code/__DEFINES/preferences.dm
+++ b/austation/code/__DEFINES/preferences.dm
@@ -1,0 +1,2 @@
+#define TYPING_INDICATOR_SAY	(1<<15)
+#define TYPING_INDICATOR_ME		(1<<16)

--- a/austation/code/modules/mob/typing_indicator.dm
+++ b/austation/code/modules/mob/typing_indicator.dm
@@ -1,0 +1,55 @@
+/mob/start_typing(source as text)
+	set name = ".start_typing"
+	set hidden = 1
+
+	switch(source)
+		if("say")
+			create_typing_indicator()
+		if("me")
+			create_typing_indicator(TRUE)
+
+/mob/living/carbon/human/create_typing_indicator(me = FALSE)
+	var/mob/living/carbon/human/H = src
+	if((HAS_TRAIT(H, TRAIT_MUTE) || H.silent) && !me)
+		remove_overlay(TYPING_LAYER)
+		return
+
+	if(client)
+		if(stat != CONSCIOUS || is_muzzled() || (client.prefs.toggles & TYPING_INDICATOR_SAY) || (me && (client.prefs.toggles & TYPING_INDICATOR_ME)))
+			remove_overlay(TYPING_LAYER)
+		else if(!overlays_standing[TYPING_LAYER])
+			overlays_standing[TYPING_LAYER] = GLOB.human_typing_indicator
+			apply_overlay(TYPING_LAYER)
+	else
+		remove_overlay(TYPING_LAYER)
+
+/client/verb/typing_indicator()
+	set name = "Show/Hide Typing Indicator"
+	set category = "Preferences"
+	set desc = "Toggles showing an indicator when you are typing a message."
+	prefs.toggles ^= TYPING_INDICATOR_SAY
+	prefs.save_preferences(src)
+	to_chat(src, "You will [(prefs.toggles & TYPING_INDICATOR_SAY) ? "no longer" : "now"] display a typing indicator.")
+
+	// Clear out any existing typing indicator.
+	if(prefs.toggles & TYPING_INDICATOR_SAY)
+		if(istype(mob))
+			mob.create_typing_indicator()
+
+	SSblackbox.record_feedback("tally", "toggle_verbs", 1, list("Toggle Typing Indicator (Speech)", "[usr.client.prefs.toggles & TYPING_INDICATOR_SAY ? "Disabled" : "Enabled"]"))
+
+
+/client/verb/emote_indicator()
+	set name = "Show/Hide Emote Typing Indicator"
+	set category = "Preferences"
+	set desc = "Toggles showing an indicator when you are typing an emote."
+	prefs.toggles ^= TYPING_INDICATOR_ME
+	prefs.save_preferences(src)
+	to_chat(src, "You will [(prefs.toggles & TYPING_INDICATOR_ME) ? "no longer" : "now"] display a typing indicator for emotes.")
+
+	// Clear out any existing typing indicator.
+	if(prefs.toggles & TYPING_INDICATOR_ME)
+		if(istype(mob))
+			mob.create_typing_indicator(TRUE)
+
+	SSblackbox.record_feedback("tally", "toggle_verbs", 1, list("Toggle Typing Indicator (Emote)", "[usr.client.prefs.toggles & TYPING_INDICATOR_ME ? "Disabled" : "Enabled"]"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

see title

## Why It's Good For The Game

fuck you francis
![image](https://user-images.githubusercontent.com/56778689/138542767-c9d55137-7d58-496e-be0a-59f1cacc00fe.png)


## Changelog
:cl:
fix: you can turn off typing indicators now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
