### PR TITLE
Explosive Plant Nerf

### DIFF
--- a/austation/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/austation/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -4,6 +4,7 @@
 	reagent_state = SOLID
 	color = "#FFFFFF"
 	taste_description = "salt"
+	random_unrestricted = FALSE
 
 /datum/reagent/tatp
 	name = "TaTP"
@@ -11,6 +12,7 @@
 	reagent_state = SOLID
 	color = "#FFFFFF"
 	taste_description = "death"
+	random_unrestricted = FALSE
 
 /datum/reagent/gasoline
 	name = "Petrol"

--- a/austation/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/austation/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -1,3 +1,6 @@
+/datum/chemical_reaction/reagent_explosion/nitroglycerin
+	required_temp = 374 //Stops nitroglycerin from exploding on formation : done as part of limiting explosive plants
+
 /datum/chemical_reaction/reagent_explosion/rdx
 	results = list(/datum/reagent/rdx= 2)
 	required_reagents = list(/datum/reagent/phenol = 2, /datum/reagent/toxin/acid/nitracid = 1, /datum/reagent/acetone_oxide = 1 )

--- a/austation/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/austation/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -1,5 +1,9 @@
-/datum/chemical_reaction/reagent_explosion/nitroglycerin
-	required_temp = 374 //Stops nitroglycerin from exploding on formation : done as part of limiting explosive plants
+/datum/chemical_reaction/reagent_explosion/nitroglycerin/on_reaction(datum/reagents/holder, created_volume)
+	holder.chem_temp += created_volume*5
+	return
+
+/datum/chemical_reaction/reagent_explosion/nitroglycerin_explosion
+	required_temp = 385
 
 /datum/chemical_reaction/reagent_explosion/rdx
 	results = list(/datum/reagent/rdx= 2)


### PR DESCRIPTION
## About The Pull Request
blacklists RDX & TATP from strange seeds

nitro no longer explodes on mix, is now an exothermic reaction `creation volume * 5 heat`
nitro explosion temp reduced from 474 to 385

## Changelog
:cl:
balance: removed RDX & TATP from strange seeds
tweak: nitro is now an exothermic reaction that explodes at 385
/:cl: