### PR TITLE
Removes Botany Hand Holding

### DIFF
--- a/_maps/map_files/Austation/Austation.dmm
+++ b/_maps/map_files/Austation/Austation.dmm
@@ -24845,7 +24845,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/chem_dispenser/mutagensaltpetersmall,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "ccv" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes botany chem dispenser, botany has ghetto alternatives as well as just getting it from chem or getting engineering to build them one.

## Changelog
:cl:
del: removes botany chem dispenser
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
