### PR TITLE
Removes stimulum from strange seed pool

### DIFF
--- a/austation/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/austation/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -64,6 +64,9 @@
 	max_brightness = 6
 	power = 1.8
 
+/datum/reagent/stimulum
+	can_synth = FALSE
+
 /datum/reagent/stimulum/on_mob_metabolize(mob/living/L)
 	..()
 	L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=-1, blacklisted_movetypes=(FLYING|FLOATING))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes stimulum from the possible reagents in strange seeds

## Why It's Good For The Game
Pretty powerful stuff for something you can mass produce in botany
## Changelog
:cl:
balance: Stimulum can no longer be found in strange seeds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
