### PR TITLE
Discovery Research Removal

### DIFF
--- a/austation.dme
+++ b/austation.dme
@@ -284,6 +284,7 @@
 #include "austation\code\modules\research\designs\medical_designs.dm"
 #include "austation\code\modules\research\techweb\_techweb_node.dm"
 #include "austation\code\modules\research\techweb\all_nodes.dm"
+#include "austation\code\modules\shuttle\super_cruise\orbital_poi_generator\loot\research_disks.dm"
 #include "austation\code\modules\surgery\advanced\bioware\cortex_folding.dm"
 #include "austation\code\modules\surgery\advanced\bioware\cortex_imprint.dm"
 #include "austation\code\modules\surgery\organs\eyes.dm"

--- a/austation/code/modules/research/techweb/_techweb_node.dm
+++ b/austation/code/modules/research/techweb/_techweb_node.dm
@@ -7,3 +7,6 @@
 	design_ids -= austation_design_ids_remove
 	design_ids += austation_design_ids
 	..()
+
+/datum/techweb_node/calculate_discovery_cost(their_tier)
+	return 0

--- a/austation/code/modules/research/techweb/all_nodes.dm
+++ b/austation/code/modules/research/techweb/all_nodes.dm
@@ -5,6 +5,14 @@
 
 /////////////////////////Bluespace tech/////////////////////////
 
+/datum/techweb_node/bag_of_holding
+	hidden = FALSE
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
+
+/datum/techweb_node/quantum_spin
+	hidden = FALSE
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
+
 /datum/techweb_node/micro_bluespace
 	austation_design_ids = list("bluespace_belt")
 
@@ -50,6 +58,14 @@
 
 /////////////////////////Advanced Surgery/////////////////////////
 
+/datum/techweb_node/combat_cyber_implants
+	hidden = FALSE
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
+
+/datum/techweb_node/adv_combat_cyber_implants
+	hidden = FALSE
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+
 /datum/techweb_node/exp_surgery
 	austation_design_ids = list("surgery_cortex_imprint", "surgery_cortex_folding")
 
@@ -62,7 +78,12 @@
 	austation_design_ids = list("dadbot_module", "rickroll_module", "dagothur_module", "crewsimov_module", "disboard_module")
 	austation_design_ids_remove = list("aiupload")
 
+
 ////////////////////////mech technology////////////////////////
+
+/datum/techweb_node/phazon
+	hidden = FALSE
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 
 /datum/techweb_node/adv_mecha_tools
 	austation_design_ids = list("mech_ion_thrusters")
@@ -71,3 +92,22 @@
 
 /datum/techweb_node/bio_process
 	austation_design_ids = list("cake_printer")
+
+/////////////////////////weaponry tech/////////////////////////
+
+/datum/techweb_node/exotic_ammo
+	hidden = FALSE
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+
+/datum/techweb_node/beam_weapons
+	hidden = FALSE
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+
+/datum/techweb_node/adv_beam_weapons
+	hidden = FALSE
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+
+/datum/techweb_node/radioactive_weapons
+	hidden = FALSE
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+

--- a/austation/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/research_disks.dm
+++ b/austation/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/research_disks.dm
@@ -1,0 +1,10 @@
+/obj/item/disk/tech_disk/research/Initialize()
+	. = ..()
+
+	if(node_id)
+		var/datum/techweb/techweb_datum = new /datum/techweb
+		var/datum/techweb_node/node = SSresearch.techweb_node_by_id(node_id)
+
+		techweb_datum.researched_nodes = list()
+		techweb_datum.research_node(node, TRUE, FALSE, FALSE)
+		stored_research = techweb_datum


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Bacon exploration changes to RnD were added only to promote his own project, Exploration. Bacon did this without care, discovery research has a generic proc to assign cost to all tiers above zero of research nodes regardless of its actual in game value. Not designed to be an engaging mechanic but to force players into his own project this pr removes it and gives the job a more natural RnD effect like other research jobs.

- Removes discovery research cost from nodes.
- Adds back the following techs : bag of holding 10k RP, quantum_spin 7.5k RP, combat_cyber_implants 7.5k RP, adv_combat_cyber_implants 5k RP, phazon 10k RP, exotic_ammo 5k RP, beam_weapons 5k RP, adv_beam_weapons 5k RP and radioactive_weapons 5k RP.
- Tweaks exploration disks to give the full node.

## Changelog
:cl:
tweak: sets the discovery research cost of all nodes to zero.
tweak: adds back bag_of_holding, quantum_spin, combat_cyber_implants, adv_combat_cyber_implants, phazon, exotic_ammo, beam_weapons, adv_beam_weapons and radioactive_weapons techs.
tweak: exploration tech disks now completely unlock the corresponding tech.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
