### PR TITLE
Gympie Gympie Additions

### DIFF
--- a/austation/code/modules/hydroponics/grown/gympie_gympie.dm
+++ b/austation/code/modules/hydroponics/grown/gympie_gympie.dm
@@ -39,7 +39,7 @@
 
 /obj/item/seeds/gympie_gympie/on_reagent_change(changetype)
 	if(changetype == ADD_REAGENT)
-		var/datum/reagent/medicine/strange_reagent/S = reagents.has_reagent(awaken_reagent)
+		var/S = reagents.has_reagent(awaken_reagent)
 		if(S)
 			spawn(30)
 				if(!QDELETED(src))
@@ -51,6 +51,7 @@
 					G.type_count = 0
 					G.gympie_poison = list()
 					G.health = G.maxHealth
+					G.name = name
 					for(var/datum/plant_gene/reagent/R in genes)
 						G.gympie_poison += R.reagent_id
 						G.type_count++

--- a/austation/code/modules/hydroponics/grown/gympie_gympie.dm
+++ b/austation/code/modules/hydroponics/grown/gympie_gympie.dm
@@ -17,7 +17,7 @@
 	reagents_add = list(/datum/reagent/toxin/mindbreaker = 0.10)
 	rarity = 50
 	var/volume = 5
-	var/awaken_reagent = /datum/reagent/plantnutriment/left4zednutriment //Muh' debug purposes, leave this for gimmicks
+	var/awaken_reagent = /datum/reagent/plantnutriment/left4zednutriment //Muh' debug purposes, leave this for gimmicks.
 
 /obj/item/reagent_containers/food/snacks/grown/gympie_gympie
 	seed = /obj/item/seeds/gympie_gympie

--- a/austation/code/modules/hydroponics/grown/gympie_gympie.dm
+++ b/austation/code/modules/hydroponics/grown/gympie_gympie.dm
@@ -1,5 +1,6 @@
 /obj/item/seeds/gympie_gympie
 	name = "pack of gympie gympie seeds"
+	var/babys_first_name = "Gympie Gympie"
 	desc = "These seeds grow into a gympie gympie plant"
 	icon = 'austation/icons/obj/hydroponics/popes_selection.dmi'
 	icon_state = "seed-gympie_gympie"
@@ -51,7 +52,7 @@
 					G.type_count = 0
 					G.gympie_poison = list()
 					G.health = G.maxHealth
-					G.name = name
+					G.name = babys_first_name
 					for(var/datum/plant_gene/reagent/R in genes)
 						G.gympie_poison += R.reagent_id
 						G.type_count++
@@ -62,4 +63,15 @@
 							G.sting_boy = 1
 					G.visible_message("<span class='notice'>The Gympie Gympie violently shakes its leafs at you!</span>")
 					qdel(src)
+
+/obj/item/seeds/gympie_gympie/attackby(obj/item/W, mob/user)//Name the child
+	if(istype(W, /obj/item/pen))
+		var/new_name = stripped_input(user, "What would you like the name to be?")
+		if(!user.canUseTopic(src, BE_CLOSE))
+			return
+		if(new_name)
+			babys_first_name = new_name
+		return
+	else
+		return ..()
 

--- a/austation/code/modules/hydroponics/grown/gympie_gympie.dm
+++ b/austation/code/modules/hydroponics/grown/gympie_gympie.dm
@@ -72,6 +72,5 @@
 		if(new_name)
 			babys_first_name = new_name
 			name = "pack of [new_name] seeds"
-		return
 	return ..()
 

--- a/austation/code/modules/hydroponics/grown/gympie_gympie.dm
+++ b/austation/code/modules/hydroponics/grown/gympie_gympie.dm
@@ -71,7 +71,7 @@
 			return
 		if(new_name)
 			babys_first_name = new_name
-			name = new_name
+			name = "pack of [new_name] seeds"
 		return
 	return ..()
 

--- a/austation/code/modules/hydroponics/grown/gympie_gympie.dm
+++ b/austation/code/modules/hydroponics/grown/gympie_gympie.dm
@@ -40,8 +40,7 @@
 
 /obj/item/seeds/gympie_gympie/on_reagent_change(changetype)
 	if(changetype == ADD_REAGENT)
-		var/S = reagents.has_reagent(awaken_reagent)
-		if(S)
+		if(reagents.has_reagent(awaken_reagent))
 			spawn(30)
 				if(!QDELETED(src))
 					var/mob/living/simple_animal/hostile/gympie_gympie/G = new /mob/living/simple_animal/hostile/gympie_gympie(get_turf(src.loc))

--- a/austation/code/modules/hydroponics/grown/gympie_gympie.dm
+++ b/austation/code/modules/hydroponics/grown/gympie_gympie.dm
@@ -71,6 +71,7 @@
 			return
 		if(new_name)
 			babys_first_name = new_name
+			name = new_name
 		return
 	else
 		return ..()

--- a/austation/code/modules/hydroponics/grown/gympie_gympie.dm
+++ b/austation/code/modules/hydroponics/grown/gympie_gympie.dm
@@ -73,6 +73,5 @@
 			babys_first_name = new_name
 			name = new_name
 		return
-	else
-		return ..()
+	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the ability to rename spawned Gympies through editing seed-names.
Also changes some odd code...

## Why It's Good For The Game

Botanists should be able to annotate the species of Gympie they produce to effectively communicate their intentions to allies. 
Odd code is odd.

## Changelog
:cl:
add: Gympies inherit edited seed-names
tweak: Changes some weird code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
