### PR TITLE
mech fab can produce ATVs

### DIFF
--- a/austation/code/modules/research/designs/mecha_designs.dm
+++ b/austation/code/modules/research/designs/mecha_designs.dm
@@ -23,7 +23,7 @@
 	desc = "A quad bike for traversing uneven terrain effortlessly."
 	id = "print_atv"
 	build_type = MECHFAB
-	build_path = /obj/vehicle/ridden/atv
+	build_path = list(/obj/vehicle/ridden/atv, /obj/item/key)
 	materials = list(/datum/material/titanium=3000,/datum/material/plastic=1000,/datum/material/iron=2000)
 	construction_time = 500
 	category = list("Misc")

--- a/austation/code/modules/research/designs/mecha_designs.dm
+++ b/austation/code/modules/research/designs/mecha_designs.dm
@@ -24,6 +24,6 @@
 	id = "print_atv"
 	build_type = MECHFAB
 	build_path = /obj/vehicle/ridden/atv
-	materials = list(/datum/material/titanium=3000,/datum/material/plastic/=1000,/datum/material/iron=2000)
+	materials = list(/datum/material/titanium=3000,/datum/material/plastic=1000,/datum/material/iron=2000)
 	construction_time = 500
 	category = list("Misc")

--- a/austation/code/modules/research/designs/mecha_designs.dm
+++ b/austation/code/modules/research/designs/mecha_designs.dm
@@ -17,3 +17,13 @@
 	materials = list(/datum/material/iron=25000,/datum/material/titanium=10000,/datum/material/gold=5000,/datum/material/plasma=10000)
 	construction_time = 500
 	category = list("Exosuit Equipment")
+
+/datum/design/atv_bike
+	name = "All Terrain Vehicle"
+	desc = "A quad bike for traversing uneven terrain effortlessly."
+	id = "print_atv"
+	build_type = MECHFAB
+	build_path = /obj/vehicle/ridden/atv
+	materials = list(/datum/material/titanium=3000,/datum/material/plastic/=1000,/datum/material/iron=2000)
+	construction_time = 500
+	category = list("Misc")

--- a/austation/code/modules/research/techweb/all_nodes.dm
+++ b/austation/code/modules/research/techweb/all_nodes.dm
@@ -88,6 +88,17 @@
 /datum/techweb_node/adv_mecha_tools
 	austation_design_ids = list("mech_ion_thrusters")
 
+/datum/techweb_node/atv
+	id = "print_atv"
+	tech_tier = 3
+	display_name = "All Terain Vehicles"
+	description = "Technology that allows the printing of quad bikes"
+	prereq_ids = list("adv_engi")
+	hidden = FALSE
+	research_costs = list(TECHWEB_POINT_TYPE_DISCOVERY = 10000)
+	austation_design_ids = list("print_atv")
+	export_price = 10000
+
 ////////////////////////bio processing////////////////////////
 
 /datum/techweb_node/bio_process

--- a/austation/code/modules/research/techweb/all_nodes.dm
+++ b/austation/code/modules/research/techweb/all_nodes.dm
@@ -93,9 +93,9 @@
 	tech_tier = 3
 	display_name = "All Terain Vehicles"
 	description = "Technology that allows the printing of quad bikes"
-	prereq_ids = list("adv_engi")
+	prereq_ids = list("movable_shells", "basic_shuttle")
 	hidden = FALSE
-	research_costs = list(TECHWEB_POINT_TYPE_DISCOVERY = 10000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	austation_design_ids = list("print_atv")
 	export_price = 10000
 


### PR DESCRIPTION
Research the techweb node in science for 10k discovery points, after finishing advanced engineering.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Science can now produce ATV bikes for miners after first researching _basic movable shells_ and _basic shuttle research_ and dumping 10k generic research points.
ATVs don't have a lot of strong suits, but they're fun and ignore damage slow downs like all vehicles.

you can print one at the mech fab for
3000 titanium
1000 plastic
2000 iron
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A fun vehicle to print in the mid/late game. it's basically just a big skateboard when it gets down to details.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: You can now research All Terrain Vehicles in science
add: ATVs can be printed at the mech fabricator
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
