### PR TITLE
Mechfabs no longer crash after building a drone shell

### DIFF
--- a/austation/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/austation/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -27,4 +27,20 @@
 	if(istype(J))
 		return J
 
+/obj/item/drone_shell
+	name = "hand-held drone shell"
+	desc = "a drone shell yet to be activated. use it in your hand to activate the drone shell."
+	w_class = WEIGHT_CLASS_NORMAL
+	icon = 'icons/mob/drone.dmi'
+	icon_state = "drone_maint_grey"
 
+/obj/item/drone_shell/attack_self(mob/user)
+	. = ..()
+	var/turf/T = get_turf(src)
+	if(!T)
+		user.show_message("<span class='warning'> There is no room to build \the [src].</span>")
+		return
+	user.visible_message("<span class='notice'> [user] begins to build \a [src].</span>", "<span class='notice'> You begin to build \the [src].</span>", "<span class='notice'> You can hear someone building \a [src].</span>", 7)
+	var/obj/effect/mob_spawn/drone/new_drone
+	new_drone = new(T)
+	qdel(src)

--- a/austation/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/austation/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -44,5 +44,5 @@
 	user.visible_message("<span class='notice'> [user] builds \a [src].</span>", "<span class='notice'> You build \the [src].</span>", "<span class='notice'> You can hear someone building \a [src].</span>", 7)
 	var/obj/effect/mob_spawn/drone/new_drone = new(T)
 	for(var/i in 1 to 4)  //  The same playsound behaviour used when borgs choose a module
-		playsound(R, pick('sound/items/drill_use.ogg', 'sound/items/jaws_cut.ogg', 'sound/items/jaws_pry.ogg', 'sound/items/welder.ogg', 'sound/items/ratchet.ogg'), 80, 1, -1)
+		playsound(new_drone, pick('sound/items/drill_use.ogg', 'sound/items/jaws_cut.ogg', 'sound/items/jaws_pry.ogg', 'sound/items/welder.ogg', 'sound/items/ratchet.ogg'), 80, 1, -1)
 	qdel(src)

--- a/austation/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/austation/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -29,7 +29,7 @@
 
 /obj/item/drone_shell
 	name = "hand-held drone shell"
-	desc = "a drone shell yet to be activated. use it in your hand to activate the drone shell."
+	desc = "A drone shell yet to be activated. use it in your hand to activate the drone shell."
 	w_class = WEIGHT_CLASS_NORMAL
 	icon = 'icons/mob/drone.dmi'
 	icon_state = "drone_maint_grey"
@@ -41,6 +41,5 @@
 		user.show_message("<span class='warning'> There is no room to build \the [src].</span>")
 		return
 	user.visible_message("<span class='notice'> [user] begins to build \a [src].</span>", "<span class='notice'> You begin to build \the [src].</span>", "<span class='notice'> You can hear someone building \a [src].</span>", 7)
-	var/obj/effect/mob_spawn/drone/new_drone
-	new_drone = new(T)
+	var/obj/effect/mob_spawn/drone/new_drone = new(T)
 	qdel(src)

--- a/austation/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/austation/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -29,7 +29,7 @@
 
 /obj/item/drone_shell
 	name = "hand-held drone shell"
-	desc = "A drone shell yet to be activated. use it in your hand to activate the drone shell."
+	desc = "A drone shell yet to be activated. Use it in your hand to activate the drone shell."
 	w_class = WEIGHT_CLASS_NORMAL
 	icon = 'icons/mob/drone.dmi'
 	icon_state = "drone_maint_grey"
@@ -42,6 +42,5 @@
 		return
 
 	user.visible_message("<span class='notice'> [user] builds \a [src].</span>", "<span class='notice'> You build \the [src].</span>", "<span class='notice'> You can hear someone building \a [src].</span>", 7)
-	var/obj/effect/mob_spawn/drone/new_drone
-	new_drone = new(T)
+	var/obj/effect/mob_spawn/drone/new_drone = new(T)
 	qdel(src)

--- a/austation/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/austation/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -40,6 +40,8 @@
 	if(!T)
 		user.show_message("<span class='warning'> There is no room to build \the [src].</span>")
 		return
-	user.visible_message("<span class='notice'> [user] begins to build \a [src].</span>", "<span class='notice'> You begin to build \the [src].</span>", "<span class='notice'> You can hear someone building \a [src].</span>", 7)
-	var/obj/effect/mob_spawn/drone/new_drone = new(T)
+
+	user.visible_message("<span class='notice'> [user] builds \a [src].</span>", "<span class='notice'> You build \the [src].</span>", "<span class='notice'> You can hear someone building \a [src].</span>", 7)
+	var/obj/effect/mob_spawn/drone/new_drone
+	new_drone = new(T)
 	qdel(src)

--- a/austation/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/austation/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -41,7 +41,7 @@
 		user.show_message("<span class='warning'> There is no room to build \the [src].</span>")
 		return
 
-	user.visible_message("<span class='notice'> [user] builds \a [src].</span>", "<span class='notice'> You build \the [src].</span>", "<span class='notice'> You can hear someone building \a [src].</span>", 7)
+	user.visible_message("<span class='notice'>[user] activates \a [src].</span>", "<span class='notice'>You activate \the [src].</span>")
 	var/obj/effect/mob_spawn/drone/new_drone = new(T)
 	for(var/i in 1 to 4)  //  The same playsound behaviour used when borgs choose a module
 		playsound(new_drone, pick('sound/items/drill_use.ogg', 'sound/items/jaws_cut.ogg', 'sound/items/jaws_pry.ogg', 'sound/items/welder.ogg', 'sound/items/ratchet.ogg'), 80, 1, -1)

--- a/austation/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/austation/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -43,4 +43,6 @@
 
 	user.visible_message("<span class='notice'> [user] builds \a [src].</span>", "<span class='notice'> You build \the [src].</span>", "<span class='notice'> You can hear someone building \a [src].</span>", 7)
 	var/obj/effect/mob_spawn/drone/new_drone = new(T)
+	for(var/i in 1 to 4)  //  The same playsound behaviour used when borgs choose a module
+		playsound(R, pick('sound/items/drill_use.ogg', 'sound/items/jaws_cut.ogg', 'sound/items/jaws_pry.ogg', 'sound/items/welder.ogg', 'sound/items/ratchet.ogg'), 80, 1, -1)
 	qdel(src)

--- a/austation/code/modules/research/designs/mechfabricator_designs.dm
+++ b/austation/code/modules/research/designs/mechfabricator_designs.dm
@@ -86,7 +86,7 @@
 	desc = "A shell of a maintenance drone, an expendable robot built to perform station repairs.."
 	id = "drone_shell"
 	build_type = MECHFAB
-	build_path = /obj/effect/mob_spawn/drone
+	build_path = /obj/item/drone_shell
 	materials = list(/datum/material/iron=2000,/datum/material/gold=200,/datum/material/glass=1500)
 	construction_time = 100
 	category = list("Misc")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the issue where mech fabs would crash after building a drone shell by printing an item instead of a mob_spawn.
This drone_shell item will create the respective mob_spawn upon using in-hand.

As an added effect, the new drone_shell items can be carried around before activating them in their final position - as opposed to rooting themself to the spot in front of the fab like the mob_spawner does.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mechfabs don't crash after building a drone shell anymore, enough said.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: printable hand-held drone shells, that can be carried around with you until you want to activate them.
tweak: drone shells no longer stick to the floor immediately after you print them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
