### PR TITLE
Adds more crayons and pens to the HoP office

### DIFF
--- a/_maps/map_files/Austation/Austation.dmm
+++ b/_maps/map_files/Austation/Austation.dmm
@@ -16714,6 +16714,10 @@
 /area/crew_quarters/heads/hop)
 "bwm" = (
 /obj/structure/filingcabinet/chestdrawer/wheeled,
+/obj/item/clothing/accessory/pocketprotector,
+/obj/item/storage/crayons,
+/obj/item/pen/fourcolor,
+/obj/item/pen/fountain,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "bwn" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The HoP now has a box of crayons, a fountain pen and a four-colour pen in his office, for those extrenuating circumstances under which the standard black ballpoint simply won't do.

![image](https://user-images.githubusercontent.com/23044898/147326808-b245764d-2dca-4c26-9f59-9dc7bdad3f61.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Article 10a, section 3 is for office use only and must be marked clearly in red.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Hop Office starts with more pen and crayon diversity.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
