### PR TITLE
Makes the Ancestor announcer slightly more common

### DIFF
--- a/austation/code/datums/station_traits/neutral_traits.dm
+++ b/austation/code/datums/station_traits/neutral_traits.dm
@@ -1,7 +1,7 @@
 /datum/station_trait/announcement_ancestor
 	name = "Announcer: Ancestor"
 	trait_type = STATION_TRAIT_NEUTRAL
-	weight = 1
+	weight = 2
 	show_in_report = TRUE
 	report_message = "Wayne June has generously donated his time to provide some spooky announcement lines for the season"
 	blacklist = list( /datum/station_trait/announcement_medbot,

--- a/austation/code/datums/station_traits/neutral_traits.dm
+++ b/austation/code/datums/station_traits/neutral_traits.dm
@@ -1,7 +1,7 @@
 /datum/station_trait/announcement_ancestor
 	name = "Announcer: Ancestor"
 	trait_type = STATION_TRAIT_NEUTRAL
-	weight = 2
+	weight = 3
 	show_in_report = TRUE
 	report_message = "Wayne June has generously donated his time to provide some spooky announcement lines for the season"
 	blacklist = list( /datum/station_trait/announcement_medbot,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the weight of the Ancestor station trait from 1 to 3, making it equal to the intern trait
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
After months of the trait not triggering, I realize that a weight of 1 is probably a bit too low for a trait that has 3 mutually exclusive alternitives.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Slightly increased the chance for the ancestor announcer to trigger 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
