### PR TITLE
'Fix' xenobiology mapping inconsistency 

### DIFF
--- a/_maps/map_files/Austation/Austation.dmm
+++ b/_maps/map_files/Austation/Austation.dmm
@@ -33310,7 +33310,7 @@
 	req_access_txt = "47"
 	},
 /turf/open/floor/plating,
-/area/science/xenobiology)
+/area/maintenance/department/science/xenobiology)
 "cTw" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/item/storage/box/lights/mixed,
@@ -34936,7 +34936,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/science/xenobiology)
+/area/maintenance/department/science/xenobiology)
 "ddq" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"


### PR DESCRIPTION
## About The Pull Request

Just watched someone get assblasted by a radiation storm because xenobio's maints are mapped differently to every other maint

**NEW**
![image](https://user-images.githubusercontent.com/40559528/153744129-2f30853a-5ed2-486d-aec5-6a2111a31972.png)

**OLD**
![image](https://user-images.githubusercontent.com/40559528/153744142-a657a858-f767-4a16-9b8d-c90ba4e3a9e3.png)

## Why It's Good For The Game

;)

## Changelog
:cl:
tweak: Changed xenobio maints to extrude to the airlock
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
