### PR TITLE
I own a egun for home defence

### DIFF
--- a/austation.dme
+++ b/austation.dme
@@ -21,7 +21,10 @@
 
 // BEGIN_INCLUDE
 #include "austation\code\modules\projectiles\ammunition\energy\_energy.dm"
+#include "austation\code\modules\projectiles\ammunition\energy\laser.dm"
 #include "austation\code\modules\projectiles\ammunition\energy\stun.dm"
+#include "austation\code\modules\projectiles\guns\energy\energy_gun.dm"
+#include "austation\code\modules\projectiles\guns\energy\laser.dm"
 #include "austation\code\modules\relay\relay.dm"
 #include "austation\code\modules\research\techweb\_techweb_node.dm"
 #include "austation\code\modules\research\techweb\all_nodes.dm"

--- a/austation.dme
+++ b/austation.dme
@@ -20,6 +20,8 @@
 // END_BEE_INCLUDE
 
 // BEGIN_INCLUDE
+#include "austation\code\modules\projectiles\ammunition\energy\_energy.dm"
+#include "austation\code\modules\projectiles\ammunition\energy\stun.dm"
 #include "austation\code\modules\relay\relay.dm"
 #include "austation\code\modules\research\techweb\_techweb_node.dm"
 #include "austation\code\modules\research\techweb\all_nodes.dm"

--- a/austation/code/modules/projectiles/ammunition/energy/_energy.dm
+++ b/austation/code/modules/projectiles/ammunition/energy/_energy.dm
@@ -1,2 +1,2 @@
 /obj/item/ammo_casing/energy
-	e_cost = 50
+	e_cost = 50 //20 shots

--- a/austation/code/modules/projectiles/ammunition/energy/_energy.dm
+++ b/austation/code/modules/projectiles/ammunition/energy/_energy.dm
@@ -1,0 +1,3 @@
+/obj/item/ammo_casing/energy
+	..()
+	e_cost = 50

--- a/austation/code/modules/projectiles/ammunition/energy/_energy.dm
+++ b/austation/code/modules/projectiles/ammunition/energy/_energy.dm
@@ -1,3 +1,2 @@
 /obj/item/ammo_casing/energy
-	..()
 	e_cost = 50

--- a/austation/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/austation/code/modules/projectiles/ammunition/energy/laser.dm
@@ -1,0 +1,5 @@
+/obj/item/ammo_casing/energy/lasergun
+	e_cost = 40 //25 shots
+
+/obj/item/ammo_casing/energy/laser/hos
+	e_cost = 40 //30 shots

--- a/austation/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/austation/code/modules/projectiles/ammunition/energy/stun.dm
@@ -1,0 +1,3 @@
+/obj/item/ammo_casing/energy/disabler
+	..()
+	e_cost = 20

--- a/austation/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/austation/code/modules/projectiles/ammunition/energy/stun.dm
@@ -1,2 +1,5 @@
 /obj/item/ammo_casing/energy/disabler
-	e_cost = 20
+	e_cost = 40 //25 shots
+
+/obj/item/ammo_casing/energy/disabler/hos
+	e_cost = 40 //30 shots

--- a/austation/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/austation/code/modules/projectiles/ammunition/energy/stun.dm
@@ -1,3 +1,2 @@
 /obj/item/ammo_casing/energy/disabler
-	..()
 	e_cost = 20

--- a/austation/code/modules/projectiles/guns/energy.dm
+++ b/austation/code/modules/projectiles/guns/energy.dm
@@ -1,0 +1,3 @@
+/obj/item/gun/energy
+	..()
+	var/cell_type = /obj/item/stock_parts/cell/upgraded

--- a/austation/code/modules/projectiles/guns/energy.dm
+++ b/austation/code/modules/projectiles/guns/energy.dm
@@ -1,3 +1,0 @@
-/obj/item/gun/energy
-	..()
-	var/cell_type = /obj/item/stock_parts/cell/upgraded

--- a/austation/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/austation/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -1,0 +1,5 @@
+/obj/item/gun/energy/e_gun
+	desc = "A basic hybrid energy gun with two settings: disable and kill. The disable mode uses 25% less power."
+
+/obj/item/gun/energy/e_gun/hos
+	desc = "This is an expensive, modern recreation of an antique laser gun. This gun has several unique firemodes, but lacks the ability to recharge over time. The gun has 1200 charge. MODES: Taser: 300, lethal/disable: 40."

--- a/austation/code/modules/projectiles/guns/energy/laser.dm
+++ b/austation/code/modules/projectiles/guns/energy/laser.dm
@@ -1,0 +1,2 @@
+/obj/item/gun/energy/laser
+	desc = "A basic laser gun, more optimised than an egun and can fire 5 additional shots"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gun descriptions are now more useful
Laser and disabler shots require 1/2 as much energy to fire, allowing for twice as many shots

## Why It's Good For The Game

When conducting science I discovered to DOWN a syndie 90% of an egun's charge is required. This means to kill them you must fix bayonets. Comparing this to a musket, a typical rapscallion can be killed in ONE shot, therefore, comparatively, muskets are MORE effective than eguns, this simply will not do. Not to mention muskets can be reloaded on the battle, allowing for many dead rapscallions. Eguns cannot be reloaded, so to kill a syndie you must have multiple, this is silly. With this PR you will now be able to kill 1 whole syndie or down 2 syndies (assuming perfect aim).

And that is why I own an egun for station defence.

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
balance: you can now fire twice as many disabler and laser shots
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
